### PR TITLE
Add libc++ dependency in flutter_boost.podspec

### DIFF
--- a/ios/flutter_boost.podspec
+++ b/ios/flutter_boost.podspec
@@ -25,6 +25,8 @@ A new Flutter plugin make flutter better to use!
   s.dependency 'Flutter'
   s.dependency 'xservice_kit'
 
+  s.libraries = 'c++'
+
   s.ios.deployment_target = '8.0'
 end
 


### PR DESCRIPTION
There have many issues about miss libc++ in the iOS project.
like these: 
- https://github.com/alibaba/flutter_boost/issues/46
- https://github.com/alibaba/flutter_boost/issues/41
- https://github.com/alibaba/flutter_boost/issues/21
- https://github.com/alibaba/flutter_boost/issues/7

Because flutter needs 'libc++' dependencies. But I don't see related dependencies in podspec.

Adding c++ dependencies to podspec will solve this problem, so you don't need to manually add c++ dependencies every time.
