### PR TITLE
add designated initializer

### DIFF
--- a/ios/Classes/container/FLBFlutterViewContainer.h
+++ b/ios/Classes/container/FLBFlutterViewContainer.h
@@ -29,6 +29,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface FLBFlutterViewContainer  : FlutterViewController<FLBFlutterContainer>
 @property (nonatomic,copy,readwrite) NSString *name;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
 - (void)surfaceUpdated:(BOOL)appeared;
 - (void)setEnableForRunnersBatch:(BOOL)enable;
 @end

--- a/ios/Classes/container/FLBFlutterViewContainer.m
+++ b/ios/Classes/container/FLBFlutterViewContainer.m
@@ -35,6 +35,8 @@
 @interface FLBFlutterViewContainer  ()
 @property (nonatomic,strong,readwrite) NSDictionary *params;
 @property (nonatomic,assign) long long identifier;
+@property (nonatomic, copy) NSString *flbNibName;
+@property (nonatomic, strong) NSBundle *flbNibBundle;
 @end
 
 #pragma clang diagnostic push
@@ -45,19 +47,28 @@
 {
     [FLUTTER_APP.flutterProvider prepareEngineIfNeeded];
     if(self = [super initWithEngine:FLUTTER_APP.flutterProvider.engine
-                            nibName:nil
-                             bundle:nil]){
+                            nibName:_flbNibName
+                            bundle:_flbNibBundle]){
         [self _setup];
     }
     return self;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wobjc-designated-initializers"
 - (instancetype)initWithCoder:(NSCoder *)aDecoder{
     if (self = [super initWithCoder: aDecoder]) {
         NSAssert(NO, @"unsupported init method!");
         [self _setup];
     }
     return self;
+}
+#pragma pop
+
+- (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+    _flbNibName = nibNameOrNil;
+    _flbNibBundle = nibBundleOrNil;
+    return [self init];
 }
 
 - (void)setName:(NSString *)name params:(NSDictionary *)params


### PR DESCRIPTION
Hello,  由于之前的PR(#313 )有冲突，并且相关代码也有变动，所以解决方法也有变动了，就把之前的PR关闭了。解决的问题还是之前提到的 #312 

关于改动的一些解释：

由于`FLBFlutterViewContainer`没有指明`designated initializer`，所以默认的`designated initializer`是父类`FlutterViewController`的，即 `- initWithEngine:nibName:bundle:` 和 `- initWithProject:nibName:bundle:`。在 Swift 工程中，如果继承`FLBFlutterViewContainer`做一些封装，就没有办法正确调用到`FLBFlutterViewContainer`的 `- init`，只能调用父类`FlutterViewController`的`designated initializer`，即需要提供一个额外的 Engine，这显然是不想看到的。