### PR TITLE
解决Android PlatformView在前后台切换的时候消失不见的问题

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/BoostFlutterView.java
+++ b/android/src/main/java/com/idlefish/flutterboost/BoostFlutterView.java
@@ -221,6 +221,7 @@ public class BoostFlutterView extends FrameLayout {
         super.onDetachedFromWindow();
         getViewTreeObserver().removeOnGlobalLayoutListener(mGlobalLayoutListener);
         onDetach();
+        flutterEngine.getPluginRegistry().getPlatformViewsController().onFlutterViewDestroyed();
     }
 
     public BoostFlutterEngine getEngine(){

--- a/android/src/main/java/com/idlefish/flutterboost/XFlutterView.java
+++ b/android/src/main/java/com/idlefish/flutterboost/XFlutterView.java
@@ -534,7 +534,6 @@ public class XFlutterView extends FrameLayout {
 
     // detach platformviews in page in case memory leak
     flutterEngine.getPluginRegistry().getPlatformViewsController().detach();
-    flutterEngine.getPluginRegistry().getPlatformViewsController().onFlutterViewDestroyed();
 
     // Inform the Android framework that it should retrieve a new InputConnection
     // now that the engine is detached. The new InputConnection will be null, which


### PR DESCRIPTION
onFlutterViewDestroyed()这个调用的时候，会执行PlatformView#dispose()，并且会调用VirtualDisplay.release()，这句话应该是导致PlatformView消失的根本原因
所以把这句代码挪到onDetachedFromWindow的时候调用，不再BoosterFlutterActivity#onPause()里面调用