### PR TITLE
暴露createFlutterView，供在flutterView add 原生view

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/NewBoostFlutterActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/NewBoostFlutterActivity.java
@@ -228,7 +228,7 @@ public class NewBoostFlutterActivity extends Activity
     }
 
     @NonNull
-    private View createFlutterView() {
+    protected View createFlutterView() {
         return delegate.onCreateView(
                 null /* inflater */,
                 null /* container */,


### PR DESCRIPTION
原生的页面改成flutter页面，一些控件是公共的，比如搜索框，音乐播放的minbar等，需要和原生的页面共用。需要暴露createFlutterView这个接口