### PR TITLE
FlutterViewContainerManager mOnResults 关联错误修复。

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterViewContainerManager.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterViewContainerManager.java
@@ -135,8 +135,10 @@ public class FlutterViewContainerManager implements IContainerManager {
 
         final String uniqueId = ContainerRecord.genUniqueId(url);
         urlParams.put(IContainerRecord.UNIQ_KEY,uniqueId);
+
+        IContainerRecord currentTopRecord = getCurrentTopRecord();
         if(onResult != null) {
-            mOnResults.put(uniqueId,onResult);
+            mOnResults.put(currentTopRecord.uniqueId(),onResult);
         }
 
         NewFlutterBoost.instance().platform().openContainer(context,url,urlParams,requestCode,exts);


### PR DESCRIPTION

平台：Android,  Flutter 1.9.1

分支：feature/flutter_1.9_upgrade

需求场景：
1.flutter界面打开native界面后回传值给上一个界面。
2.flutter界面打开flutter界面后回传值给上一个界面。

问题：
1.flutter界面打开native界面后上一个界面无法获取回传值。
2.flutter界面打开flutter界面后上一个界面无法获取回传值。

原因：
FlutterViewContainerManager中mOnResults 是IContainerRecord的uniqueId与Flutter回调MethodChannel.Result的关联。这个关联出了问题。如下：
A页面(flutter)打开一个新B页面(flutter 或 native)时存入的是新创建的uniqueId与A页面回调的关联。当新界面B结束后A页面(NewBoostFlutterActivity)的onActivityResult会响应，并最终调用FlutterViewContainerManager中的setContainerResult，而这个时候从mOnResults拿取flutter result的回调的key是之前A页面创建的record的uniqueId（即不是新创建的uniqueId）。所以无法获取回调。

修复方案：
 打开一个新页面时，关联的uniqueId使用当前栈中的顶部IContainerRecord。

