### PR TITLE
Create no-response.yml

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,17 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 21
+
+# Label requiring a response
+responseRequiredLabel: more-information-needed
+
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.
+  
+  Thanks for your contribution.


### PR DESCRIPTION
Add no-response bot to flutter-boost. 

Maintainers just need to add more-information-needed label to the issue. The bot will automatically close the timeout issue without getting more information. If the issue adds more information after it is closed, the bot will reopen the issue and remove the more-information-needed label.