### PR TITLE
修复使用All_FLUTTER_ACTIVITY_DESTROY时crash的bug

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/NewFlutterBoost.java
+++ b/android/src/main/java/com/idlefish/flutterboost/NewFlutterBoost.java
@@ -32,6 +32,7 @@ public class NewFlutterBoost {
     static NewFlutterBoost sInstance = null;
 
     private  long FlutterPostFrameCallTime=0;
+    private Application.ActivityLifecycleCallbacks mActivityLifecycleCallbacks;
 
     public long getFlutterPostFrameCallTime(){
         return FlutterPostFrameCallTime;
@@ -55,7 +56,7 @@ public class NewFlutterBoost {
 
 
 
-        platform.getApplication().registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
+        mActivityLifecycleCallbacks = new Application.ActivityLifecycleCallbacks() {
 
             @Override
             public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
@@ -125,7 +126,8 @@ public class NewFlutterBoost {
                     mCurrentActiveActivity = null;
                 }
             }
-        });
+        };
+        platform.getApplication().registerActivityLifecycleCallbacks(mActivityLifecycleCallbacks);
 
         if (mPlatform.whenEngineStart() == ConfigBuilder.IMMEDIATELY) {
 
@@ -346,6 +348,7 @@ public class NewFlutterBoost {
 
 
     public void boostDestroy(){
+        mPlatform.getApplication().unregisterActivityLifecycleCallbacks(mActivityLifecycleCallbacks);
         if(mEngine!=null){
             mEngine.destroy();
         }

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterActivityAndFragmentDelegate.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterActivityAndFragmentDelegate.java
@@ -224,10 +224,12 @@ public class FlutterActivityAndFragmentDelegate  implements IFlutterViewContaine
         ensureAlive();
         BoostPluginRegistry registry= (BoostPluginRegistry)NewFlutterBoost.instance().getPluginRegistry();
         ActivityPluginBinding  binding=registry.getRegistrarAggregate().getActivityPluginBinding();
-        if(binding!=null&&(binding.getActivity()==this.host.getActivity())){
-            registry.getRegistrarAggregate().onDetachedFromActivityForConfigChanges();
-            flutterEngine.getActivityControlSurface().detachFromActivityForConfigChanges();
+        if (registry != null && registry.getRegistrarAggregate() != null) {
+            if (binding != null && (binding.getActivity() == this.host.getActivity())) {
+                registry.getRegistrarAggregate().onDetachedFromActivityForConfigChanges();
+                flutterEngine.getActivityControlSurface().detachFromActivityForConfigChanges();
 
+            }
         }
         flutterView.release();
     }


### PR DESCRIPTION
FlutterBoost提供了whenEngineDestory，可以设置All_FLUTTER_ACTIVITY_DESTROY = 1; //所有flutter Activity destory 时，销毁engine。使用过程中发现会导致crash的问题
1.onDestroyView时空指针异常，做了保护处理
2.FlutterBoost初始化的时候注册了页面生命周期的监听，但是销毁引擎的时候没有解注册。打开其他原声页面时，调用Flutter页面壳的OnDestroy，进而关闭了引擎，但是还会监听页面生命周期的变化，在原生页面onStart的时候又创建了一个Engine，但没有完全初始化。再次打开Flutter页面时一些变量没初始化，造成了空指针异常。在boostDestroy做了unregisterActivityLifecycleCallbacks