### PR TITLE
暴露boostcontainer数组；

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/Utils.java
+++ b/android/src/main/java/com/idlefish/flutterboost/Utils.java
@@ -185,7 +185,8 @@ public class Utils {
                 }
             }
         }catch (Throwable t){
-            Debuger.exception(t);
+//            Debuger.exception(t);
+            t.printStackTrace();
         }
     }
 

--- a/lib/container/container_manager.dart
+++ b/lib/container/container_manager.dart
@@ -83,6 +83,8 @@ class ContainerManagerState extends State<BoostContainerManager> {
   //Number of containers.
   int get containerCounts => _offstage.length;
 
+  List<BoostContainer> get offstage => _offstage;
+
   //Setting for current visible container.
   BoostContainerSettings get onstageSettings => _onstage.settings;
 


### PR DESCRIPTION
debug模式下statusbar处理异常时不强制抛runtime exception，只打印异常日志；