### PR TITLE
修改NewEngineIntentBuilder构造的访问权限

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/BoostFlutterActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/BoostFlutterActivity.java
@@ -73,7 +73,7 @@ public class BoostFlutterActivity extends Activity
         private Map params = new HashMap();
 
 
-        protected NewEngineIntentBuilder(@NonNull Class<? extends BoostFlutterActivity> activityClass) {
+        public NewEngineIntentBuilder(@NonNull Class<? extends BoostFlutterActivity> activityClass) {
             this.activityClass = activityClass;
         }
 


### PR DESCRIPTION
由于NewEngineIntentBuilder内部类的构造无法外部访问(protected),无法继承BoostFlutterActivity自定义，将其改为public。（然而NewEngineFragmentBuilder的构造是public的，改成一致）