### PR TITLE
[Android] Boost修改依赖方式，使用compileOnly方式。解决打包时，递归依赖出现版本号冲突问题。

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,11 +35,11 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:design:28.0.0'
-    implementation 'com.android.support:support-v4:28.0.0'
+    compileOnly 'com.android.support:appcompat-v7:28.0.0'
+    compileOnly 'com.android.support:design:28.0.0'
+    compileOnly 'com.android.support:support-v4:28.0.0'
     implementation 'android.arch.lifecycle:common-java8:1.1.1'
-    implementation 'com.alibaba:fastjson:1.2.41'
+    compileOnly 'com.alibaba:fastjson:1.2.41'
 
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -59,5 +59,8 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.alibaba:fastjson:1.2.41'
 
 }


### PR DESCRIPTION
Android 依赖修改为compileOnly方式。解决打包时，递归依赖出现版本号冲突问题。
- support系列：support-v4、appcompat-v7、design
- fastjson