### PR TITLE
精简代码，避免过多的surfaceUpdate，原因：

### DIFF
--- a/ios/Classes/1.5/FLB2FlutterEngine.m
+++ b/ios/Classes/1.5/FLB2FlutterEngine.m
@@ -49,10 +49,11 @@
         }else{
             [_engine runWithEntrypoint:nil];
         }
-        _dummy = [[FLB2FlutterViewContainer alloc] initWithEngine:_engine
-                                                          nibName:nil
-                                                           bundle:nil];
-        _dummy.name = kIgnoreMessageWithName;
+        _dummy = nil;
+//        _dummy = [[FLB2FlutterViewContainer alloc] initWithEngine:_engine
+//                                                          nibName:nil
+//                                                           bundle:nil];
+//        _dummy.name = kIgnoreMessageWithName;
         
         Class clazz = NSClassFromString(@"GeneratedPluginRegistrant");
         if (clazz) {
@@ -81,7 +82,7 @@
 - (void)resume
 {
     [[_engine lifecycleChannel] sendMessage:@"AppLifecycleState.resumed"];
-    [(FLB2FlutterViewContainer *)_engine.viewController surfaceUpdated:YES];
+//    [(FLB2FlutterViewContainer *)_engine.viewController surfaceUpdated:YES];
 }
 
 - (void)inactive
@@ -126,9 +127,12 @@
 //    if ([_dummy respondsToSelector:@selector(setEnableForRunnersBatch:)]) {
 //        [_dummy setEnableForRunnersBatch:YES];
 //    }
-    [self detach];
-    [_dummy surfaceUpdated:YES];
+//    [self detach];
+//    [_dummy surfaceUpdated:YES];
 }
 
+- (void)dealloc{
+    [self.engine setViewController:nil];
+}
 @end
 

--- a/ios/Classes/1.5/FLB2FlutterViewContainer.m
+++ b/ios/Classes/1.5/FLB2FlutterViewContainer.m
@@ -155,16 +155,6 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)viewWillAppear:(BOOL)animated
 {
-    if([FLUTTER_APP contains:self]){
-        [self surfaceUpdated:NO];
-        [self detatchFlutterEngine];
-    }else{
-        [self attatchFlutterEngine];
-        [self surfaceUpdated:YES];
-    }
-  
-    [FLUTTER_APP resume];
-    
     //For new page we should attach flutter view in view will appear
     //for better performance.
  
@@ -188,13 +178,13 @@ static NSUInteger kInstanceCounter = 0;
     
     //Ensure flutter view is attached.
     [self attatchFlutterEngine];
-    [FLUTTER_APP resume];
  
     [BoostMessageChannel didShowPageContainer:^(NSNumber *result) {}
                                            pageName:_name
                                              params:_params
                                            uniqueId:self.uniqueIDString];
-    
+    //NOTES：务必在show之后再update，否则有闪烁
+    [self surfaceUpdated:YES];
     [super viewDidAppear:animated];
 }
 
@@ -211,13 +201,11 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)viewDidDisappear:(BOOL)animated
 {
-    [FLUTTER_APP resume];
     [BoostMessageChannel didDisappearPageContainer:^(NSNumber *result) {}
                                                 pageName:_name
                                                   params:_params
                                                 uniqueId:self.uniqueIDString];
     [super viewDidDisappear:animated];
-    [FLUTTER_APP resume];
     
 }
 


### PR DESCRIPTION
1. surfaceUpdate会线程等待，且GPU资源会重设,原来的实现过多的触发了这个函数，在低端机上会卡顿。改正后略有缓解
2. 没必要有dummy VC