### PR TITLE
只在 doInitialFlutter 调用 createEngine，其他只检查mEngine

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
@@ -14,12 +14,10 @@ import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.view.FlutterMain;
 
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
 public class FlutterBoost {
-
     private Platform mPlatform;
 
     private FlutterViewContainerManager mManager;
@@ -68,9 +66,7 @@ public class FlutterBoost {
                 }
                 if (mPlatform.whenEngineStart() == ConfigBuilder.IMMEDIATELY) {
                     boostPluginRegistry();
-
                 }
-
             }
 
             @Override
@@ -81,7 +77,7 @@ public class FlutterBoost {
                 if (mCurrentActiveActivity == null) {
                     Debuger.log("Application entry foreground");
 
-                    if (createEngine() != null) {
+                    if (mEngine != null) {
                         HashMap<String, String> map = new HashMap<>();
                         map.put("type", "foreground");
                         channel().sendEvent("lifecycle", map);
@@ -113,7 +109,7 @@ public class FlutterBoost {
                 if (mCurrentActiveActivity == activity) {
                     Debuger.log("Application entry background");
 
-                    if (createEngine() != null) {
+                    if (mEngine != null) {
                         HashMap<String, String> map = new HashMap<>();
                         map.put("type", "background");
                         channel().sendEvent("lifecycle", map);
@@ -137,7 +133,7 @@ public class FlutterBoost {
                 if (mCurrentActiveActivity == activity) {
                     Debuger.log("Application entry background");
 
-                    if (createEngine() != null) {
+                    if (mEngine != null) {
                         HashMap<String, String> map = new HashMap<>();
                         map.put("type", "background");
                         channel().sendEvent("lifecycle", map);
@@ -158,9 +154,9 @@ public class FlutterBoost {
     }
 
     public void doInitialFlutter() {
-
-
-        if (mEngine != null) return;
+        if (mEngine != null) {
+            return;
+        }
 
         if (mPlatform.lifecycleListener != null) {
             mPlatform.lifecycleListener.beforeCreateEngine();
@@ -182,8 +178,7 @@ public class FlutterBoost {
         );
 
         flutterEngine.getDartExecutor().executeDartEntrypoint(entrypoint);
-        mRegistry = new BoostPluginRegistry(createEngine());
-
+        mRegistry = new BoostPluginRegistry(mEngine);
     }
 
     public void boostPluginRegistry(){
@@ -329,7 +324,6 @@ public class FlutterBoost {
 
     private FlutterEngine createEngine() {
         if (mEngine == null) {
-
             FlutterMain.startInitialization(mPlatform.getApplication());
 
             FlutterShellArgs flutterShellArgs = new FlutterShellArgs(new String[0]);


### PR DESCRIPTION
demo 里面 启动改成 FLUTTER_ACTIVITY_CREATED， 
退出到后台，再进入，再点入flutter界面会crash。

在activity的lifecyle，如果没有之前调用doInitialFlutter，不需要主动创建engine
