### PR TITLE
rm unnecessary params

### DIFF
--- a/lib/observers_holders.dart
+++ b/lib/observers_holders.dart
@@ -38,7 +38,7 @@ class ObserversHolder {
   void removeObserver<T>(T observer) =>
       _observers[T.toString()]?.remove(observer);
 
-  void cleanObservers<T>(T observer) => _observers[T.toString()]?.clear();
+  void cleanObservers<T>() => _observers[T.toString()]?.clear();
 
   Set<T> observersOf<T>() => _observers[T.toString()] ?? Set<T>();
 }


### PR DESCRIPTION
看起来参数没啥用，可以移除掉。
变动会造成 API 不兼容，考虑到升级成本不高就直接移除了