### PR TITLE
Fix type cast error with `invokeMethod` method.

### DIFF
--- a/example/lib/simple_page_widgets.dart
+++ b/example/lib/simple_page_widgets.dart
@@ -55,7 +55,7 @@ class _FirstRouteWidgetState extends State<FirstRouteWidget> {
                 print('open natve page!');
                 FlutterBoost.singleton
                     .open('native')
-                    .then((Map<String, dynamic> value) {
+                    .then((Map<dynamic, dynamic> value) {
                   print(
                       'call me when page is finished. did recieve native route result $value');
                 });
@@ -67,7 +67,7 @@ class _FirstRouteWidgetState extends State<FirstRouteWidget> {
                 print('open FF page!');
                 FlutterBoost.singleton
                     .open('firstFirst')
-                    .then((Map<String, dynamic> value) {
+                    .then((Map<dynamic, dynamic> value) {
                   print(
                       'call me when page is finished. did recieve FF route result $value');
                 });
@@ -79,7 +79,7 @@ class _FirstRouteWidgetState extends State<FirstRouteWidget> {
                 print('open second page!');
                 FlutterBoost.singleton
                     .open('second')
-                    .then((Map<String, dynamic> value) {
+                    .then((Map<dynamic, dynamic> value) {
                   print(
                       'call me when page is finished. did recieve second route result $value');
                 });
@@ -92,7 +92,7 @@ class _FirstRouteWidgetState extends State<FirstRouteWidget> {
                 FlutterBoost.singleton.open('secondStateful',
                     urlParams: <String, dynamic>{
                       'present': true
-                    }).then((Map<String, dynamic> value) {
+                    }).then((Map<dynamic, dynamic> value) {
                   print(
                       'call me when page is finished. did recieve second stateful route result $value');
                 });
@@ -105,7 +105,7 @@ class _FirstRouteWidgetState extends State<FirstRouteWidget> {
                 FlutterBoost.singleton.open('second',
                     urlParams: <String, dynamic>{
                       'present': true
-                    }).then((Map<String, dynamic> value) {
+                    }).then((Map<dynamic, dynamic> value) {
                   print(
                       'call me when page is finished. did recieve second route result $value');
                 });
@@ -167,7 +167,7 @@ class _FirstFirstRouteWidgetState extends State<FirstFirstRouteWidget> {
             print('open first page again!');
             FlutterBoost.singleton
                 .open('first')
-                .then((Map<String, dynamic> value) {
+                .then((Map<dynamic, dynamic> value) {
               print('did recieve first route result');
               print('did recieve first route result $value');
             });
@@ -195,7 +195,7 @@ class _EmbeddedFirstRouteWidgetState extends State<EmbeddedFirstRouteWidget> {
             print('open second page!');
             FlutterBoost.singleton
                 .open('second')
-                .then((Map<String, dynamic> value) {
+                .then((Map<dynamic, dynamic> value) {
               print(
                   'call me when page is finished. did recieve second route result $value');
             });
@@ -296,7 +296,7 @@ class PlatformRouteWidget extends StatelessWidget {
             print('open second page!');
             FlutterBoost.singleton
                 .open('second')
-                .then((Map<String, dynamic> value) {
+                .then((Map<dynamic, dynamic> value) {
               print(
                   'call me when page is finished. did recieve second route result $value');
             });

--- a/example_swift/lib/simple_page_widgets.dart
+++ b/example_swift/lib/simple_page_widgets.dart
@@ -15,7 +15,7 @@ class FirstRouteWidget extends StatelessWidget {
             print('open second page!');
             FlutterBoost.singleton
                 .open('second')
-                .then((Map<String, dynamic> value) {
+                .then((Map<dynamic, dynamic> value) {
               print(
                   'call me when page is finished. did recieve second route result $value');
             });

--- a/lib/flutter_boost.dart
+++ b/lib/flutter_boost.dart
@@ -69,8 +69,9 @@ class FlutterBoost {
   static void onPageStart() {
     WidgetsBinding.instance.addPostFrameCallback((Duration _) {
       singleton.channel
-          .invokeMethod<Map<String, dynamic>>('pageOnStart')
-          .then((Map<String, dynamic> pageInfo) {
+          .invokeMethod<Map<dynamic, dynamic>>('pageOnStart')
+          .then((Map<dynamic, dynamic> _pageInfo) {
+        final Map<String, dynamic> pageInfo = _pageInfo?.cast<String, dynamic>();
         if (pageInfo?.isEmpty ?? true) {
           return;
         }
@@ -137,7 +138,7 @@ class FlutterBoost {
     ContainerCoordinator.singleton.registerPageBuilders(builders);
   }
 
-  Future<Map<String, dynamic>> open(
+  Future<Map<dynamic, dynamic>> open(
     String url, {
     Map<String, dynamic> urlParams,
     Map<String, dynamic> exts,
@@ -146,7 +147,7 @@ class FlutterBoost {
     properties['url'] = url;
     properties['urlParams'] = urlParams;
     properties['exts'] = exts;
-    return channel.invokeMethod<Map<String, dynamic>>('openPage', properties);
+    return channel.invokeMethod<Map<dynamic, dynamic>>('openPage', properties);
   }
 
   Future<bool> close(

--- a/test/lib/unit/container_manager_test.dart
+++ b/test/lib/unit/container_manager_test.dart
@@ -24,7 +24,7 @@ class FirstRouteWidget extends StatelessWidget {
                 print('open second page!');
                 FlutterBoost.singleton
                     .open('second')
-                    .then((Map<String, dynamic> value) {
+                    .then((Map<dynamic, dynamic> value) {
                   print(
                       'call me when page is finished. did recieve second route result $value');
                 });
@@ -54,7 +54,7 @@ class SecondRouteWidget extends StatelessWidget {
                 print('open second page!');
                 FlutterBoost.singleton
                     .open('second')
-                    .then((Map<String, dynamic> value) {
+                    .then((Map<dynamic, dynamic> value) {
                   print(
                       'call me when page is finished. did recieve second route result $value');
                 });

--- a/test/lib/unit/page_widgets.dart
+++ b/test/lib/unit/page_widgets.dart
@@ -19,7 +19,7 @@ class FirstRouteWidget extends StatelessWidget {
                 print('open second page!');
                 FlutterBoost.singleton
                     .open('second')
-                    .then((Map<String, dynamic> value) {
+                    .then((Map<dynamic, dynamic> value) {
                   print(
                       'call me when page is finished. did recieve second route result $value');
                 });
@@ -32,7 +32,7 @@ class FirstRouteWidget extends StatelessWidget {
                 FlutterBoost.singleton.open('second',
                     urlParams: <String, dynamic>{
                       'present': true
-                    }).then((Map<String, dynamic> value) {
+                    }).then((Map<dynamic, dynamic> value) {
                   print(
                       'call me when page is finished. did recieve second route result $value');
                 });
@@ -56,7 +56,7 @@ class EmbededFirstRouteWidget extends StatelessWidget {
             print('open second page!');
             FlutterBoost.singleton
                 .open('second')
-                .then((Map<String, dynamic> value) {
+                .then((Map<dynamic, dynamic> value) {
               print(
                   'call me when page is finished. did recieve second route result $value');
             });


### PR DESCRIPTION
This fix type cast error handled in 6f8de4f .

The root cause is that dart only returned `Map<dynamic, dynamic>` rather than specific generic type when `invokeMethod` was called. For more specific generic type user can use `cast<String, dynamic>` after the result was returned.