### PR TITLE
optimized:   把XPlatformPlugin进行复用，解决了statusbar在多个activity中显示异常的问题。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ example/android/app/.classpath
 example/android/app/.project
 example/android/.project
 flutter_boost
+.flutter-plugins-dependencies

--- a/android/src/main/java/com/idlefish/flutterboost/XPlatformPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/XPlatformPlugin.java
@@ -29,8 +29,8 @@ public class XPlatformPlugin {
     public static final int DEFAULT_SYSTEM_UI = View.SYSTEM_UI_FLAG_LAYOUT_STABLE
             | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
 
-    private  Activity activity;
-    private  PlatformChannel platformChannel;
+    private Activity activity;
+    private PlatformChannel platformChannel;
     private PlatformChannel.SystemChromeStyle currentTheme;
     private int mEnabledOverlays;
 
@@ -96,26 +96,25 @@ public class XPlatformPlugin {
         }
     };
 
-    public XPlatformPlugin( PlatformChannel platformChannel) {
-
+    public XPlatformPlugin(PlatformChannel platformChannel) {
         this.platformChannel = platformChannel;
-
+        this.platformChannel.setPlatformMessageHandler(mPlatformMessageHandler);
         mEnabledOverlays = DEFAULT_SYSTEM_UI;
     }
 
     public void attachToActivity(Activity activity ){
         this.activity = activity;
-        this.platformChannel.setPlatformMessageHandler(mPlatformMessageHandler);
-
     }
+
     /**
      * Releases all resources held by this {@code PlatformPlugin}.
      * <p>
      * Do not invoke any methods on a {@code PlatformPlugin} after invoking this method.
      */
-    public void detachActivity() {
-       this.activity=null;
-       this.mPlatformMessageHandler=null;
+    public void detachActivity(Activity activity) {
+        if (activity == this.activity) {
+            this.activity = null;
+        }
     }
 
     private void playSystemSound(PlatformChannel.SoundType soundType) {

--- a/android/src/main/java/com/idlefish/flutterboost/containers/BoostFlutterActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/BoostFlutterActivity.java
@@ -56,6 +56,7 @@ public class BoostFlutterActivity extends Activity
     // Default configuration.
     protected static final String DEFAULT_BACKGROUND_MODE = BackgroundMode.opaque.name();
 
+    private static XPlatformPlugin sXPlatformPlugin;
 
     public static Intent createDefaultIntent(@NonNull Context launchContext) {
         return withNewEngine().build(launchContext);
@@ -440,8 +441,8 @@ public class BoostFlutterActivity extends Activity
 
     @Nullable
     @Override
-    public XPlatformPlugin providePlatformPlugin( @NonNull FlutterEngine flutterEngine) {
-        return new XPlatformPlugin( flutterEngine.getPlatformChannel());
+    public XPlatformPlugin providePlatformPlugin(@NonNull FlutterEngine flutterEngine) {
+        return BoostViewUtils.getPlatformPlugin(flutterEngine.getPlatformChannel());
     }
 
     /**

--- a/android/src/main/java/com/idlefish/flutterboost/containers/BoostViewUtils.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/BoostViewUtils.java
@@ -1,0 +1,24 @@
+package com.idlefish.flutterboost.containers;
+
+import com.idlefish.flutterboost.XPlatformPlugin;
+
+import io.flutter.embedding.engine.systemchannels.PlatformChannel;
+
+class BoostViewUtils {
+
+    private static volatile XPlatformPlugin mInstance;
+
+    private BoostViewUtils() {
+    }
+
+    public static XPlatformPlugin getPlatformPlugin(PlatformChannel channel) {
+        if (mInstance == null) {
+            synchronized (BoostViewUtils.class) {
+                if (mInstance == null) {
+                    mInstance = new XPlatformPlugin(channel);
+                }
+            }
+        }
+        return mInstance;
+    }
+}

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterActivityAndFragmentDelegate.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterActivityAndFragmentDelegate.java
@@ -228,7 +228,7 @@ public class FlutterActivityAndFragmentDelegate implements IFlutterViewContainer
         // Null out the platformPlugin to avoid a possible retain cycle between the plugin, this Fragment,
         // and this Fragment's Activity.
         if (platformPlugin != null) {
-            platformPlugin.detachActivity();
+            platformPlugin.detachActivity(getContextActivity());
             platformPlugin = null;
         }
 

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterFragment.java
@@ -2,8 +2,6 @@ package com.idlefish.flutterboost.containers;
 
 import android.app.Activity;
 import android.arch.lifecycle.Lifecycle;
-import android.graphics.Color;
-import android.view.*;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
@@ -17,13 +15,11 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.idlefish.flutterboost.FlutterBoost;
-import com.idlefish.flutterboost.Utils;
 import com.idlefish.flutterboost.XFlutterView;
 import com.idlefish.flutterboost.XPlatformPlugin;
 import io.flutter.embedding.android.*;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterShellArgs;
-import io.flutter.plugin.platform.PlatformPlugin;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -472,8 +468,7 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
     @Nullable
     @Override
     public XPlatformPlugin providePlatformPlugin( @NonNull FlutterEngine flutterEngine) {
-        return new XPlatformPlugin(flutterEngine.getPlatformChannel());
-
+        return BoostViewUtils.getPlatformPlugin(flutterEngine.getPlatformChannel());
     }
 
     /**


### PR DESCRIPTION
举个例子，Flutter中对Android statusbar中的icon颜色的控制，最终都是通过`SystemChrome.setSystemUIOVerlayStyle()`来进行控制的。但是其内通过成员变量进行了重复调用的优化，也就是说重复的相同调用不会被真正执行，代码如下。
![image](https://user-images.githubusercontent.com/2403578/83490949-838feb00-a4e3-11ea-94f7-85ed1cefb48a.png)

但是，混合栈中，是会多个Activity复用一个引擎，这就会导致在style相同的情况下，`SystemChrome.setSystemUIOVerlayStyle()`只会在第一个FlutterActivity中执行，而无法在第二个FlutterActivity中执行，Api约等于无用。
因此我们可以在每次Flutter页面被push的时候，调用`SystemChrome.restoreSystemUIOverlays()`刷新当前activity的样式。
![image](https://user-images.githubusercontent.com/2403578/83490978-8ee31680-a4e3-11ea-8d52-b825ee600098.png)

但是这里有个问题，现在XPlatformPlugin是每个Activity都会new一个的，因此不同的XPlatformPlugin相互之间访问不到对方的currentTheme。也就是说XPlatformPlugin最好也是跟引擎一起被Activity复用。
能被Activity复用就需要解决可能存在的内存泄漏的问题。
![image](https://user-images.githubusercontent.com/2403578/83490989-94406100-a4e3-11ea-80aa-a4b3411b3ec9.png)
