### PR TITLE
fix:fix 类型判断错误

### DIFF
--- a/lib/container/boost_container.dart
+++ b/lib/container/boost_container.dart
@@ -223,7 +223,7 @@ class BoostContainerState extends NavigatorState {
     if (canPop()) {
       super.pop<T>(result);
     } else {
-      if (T is Map<String, dynamic>) {
+      if (result is Map<String, dynamic>) {
         FlutterBoost.singleton
             .close(uniqueId, result: result as Map<String, dynamic>);
       } else {


### PR DESCRIPTION
修复pop时判断result类型错误。

修复后，flutter页面回传值都可以使用
```
Navigator.pop( {"a":"aa"});
```
这种形式，不再需要使用
```
FlutterBoost.singleton.close(xxx)
```