### PR TITLE
Pass name of BoostContainerSettings to RouteSettings, i.e. framework acknowledge the route name.

### DIFF
--- a/lib/container/boost_container.dart
+++ b/lib/container/boost_container.dart
@@ -86,7 +86,11 @@ class BoostContainer extends Navigator {
               params: settings.params,
               uniqueId: settings.uniqueId,
               animated: false,
-              settings: routeSettings,
+              settings: RouteSettings(
+                name: settings.name,
+                isInitialRoute: routeSettings.isInitialRoute,
+                arguments: routeSettings.arguments,
+              ),
               builder: settings.builder,
             );
           } else {


### PR DESCRIPTION
目前在framework层不知道`Route`的name，因为flutter boost在构建`Route`时使用的settings没有传入name。 此提交在构建`Route`时使用`BoostContainerSettings`的name，这样在framework可以拿到真正的route name。