### PR TITLE
Define a DefaultOnResult abstract class to avoid "java.lang.IllegalSt…

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -224,12 +224,13 @@ public class FlutterBoostPlugin {
                         Map<String, Object> exts = methodCall.argument("exts");
                         String url = methodCall.argument("url");
 
-                        mManager.openContainer(url, params, exts, new FlutterViewContainerManager.OnResult() {
+                        mManager.openContainer(url, params, exts, new FlutterViewContainerManager.DefaultOnResult(result) {
                             @Override
                             public void onResult(Map<String, Object> rlt) {
-                                if (result != null) {
-                                    result.success(rlt);
+                                if (getResult() != null) {
+                                    getResult().success(rlt);
                                 }
+                                setResult(null);
                             }
                         });
                     } catch (Throwable t) {

--- a/android/src/main/java/com/idlefish/flutterboost/containers/BoostFlutterActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/BoostFlutterActivity.java
@@ -1,6 +1,7 @@
 package com.idlefish.flutterboost.containers;
 
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
@@ -186,6 +187,7 @@ public class BoostFlutterActivity extends Activity
      */
     @Nullable
     @SuppressWarnings("deprecation")
+    @SuppressLint("WrongConstant")
     private Drawable getSplashScreenFromManifest() {
         try {
             ActivityInfo activityInfo = getPackageManager().getActivityInfo(


### PR DESCRIPTION
…ateException: Reply already submitted".

* two or more time invoke the same MethodChannel.Result will cause "java.lang.IllegalStateException: Reply already submitted", recommending resolve this by using a callback with member of  MethodChannel.Result, which will be release once it has been invoke.