### PR TITLE
Don't intercept onTouch event when flutter view is not attached.

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/XFlutterView.java
+++ b/android/src/main/java/com/idlefish/flutterboost/XFlutterView.java
@@ -458,10 +458,6 @@ public class XFlutterView extends FrameLayout {
    */
   @Override
   public boolean onTouchEvent(@NonNull MotionEvent event) {
-    if (!isAttachedToFlutterEngine()) {
-      return super.onTouchEvent(event);
-    }
-
     // TODO(abarth): This version check might not be effective in some
     // versions of Android that statically compile code and will be upset
     // at the lack of |requestUnbufferedDispatch|. Instead, we should factor


### PR DESCRIPTION
修复同时点击两个按钮打开新页面时，导致返回时 flutter 点击事件处理故障的问题。

当双指同时操作页面，且页面有多个按钮可以跳转新页面时，很容易出现该问题。

现象为当同时（或先后把手指放到两个按钮上）跳转新页面后，点击导航栏返回按钮或 back 键返回上一个页面时，上一个页面的按钮点击事件失效，或者 ListView 滚动失去惯性。
