### PR TITLE
Partially revert type cast with params.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,22 +17,22 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     FlutterBoost.singleton.registerPageBuilders(<String, PageBuilder>{
-      'embeded': (String pageName, Map<String, dynamic> params, String _) =>
+      'embeded': (String pageName, Map<dynamic, dynamic> params, String _) =>
           EmbeddedFirstRouteWidget(),
-      'first': (String pageName, Map<String, dynamic> params, String _) => FirstRouteWidget(),
-      'firstFirst': (String pageName, Map<String, dynamic> params, String _) =>
+      'first': (String pageName, Map<dynamic, dynamic> params, String _) => FirstRouteWidget(),
+      'firstFirst': (String pageName, Map<dynamic, dynamic> params, String _) =>
           FirstFirstRouteWidget(),
-      'second': (String pageName, Map<String, dynamic> params, String _) => SecondRouteWidget(),
-      'secondStateful': (String pageName, Map<String, dynamic> params, String _) =>
+      'second': (String pageName, Map<dynamic, dynamic> params, String _) => SecondRouteWidget(),
+      'secondStateful': (String pageName, Map<dynamic, dynamic> params, String _) =>
           SecondStatefulRouteWidget(),
-      'tab': (String pageName, Map<String, dynamic> params, String _) => TabRouteWidget(),
-      'platformView': (String pageName, Map<String, dynamic> params, String _) =>
+      'tab': (String pageName, Map<dynamic, dynamic> params, String _) => TabRouteWidget(),
+      'platformView': (String pageName, Map<dynamic, dynamic> params, String _) =>
           PlatformRouteWidget(),
-      'flutterFragment': (String pageName, Map<String, dynamic> params, String _) =>
+      'flutterFragment': (String pageName, Map<dynamic, dynamic> params, String _) =>
           FragmentRouteWidget(params),
 
       ///可以在native层通过 getContainerParams 来传递参数
-      'flutterPage': (String pageName, Map<String, dynamic> params, String _) {
+      'flutterPage': (String pageName, Map<dynamic, dynamic> params, String _) {
         print('flutterPage params:$params');
 
         return FlutterRouteWidget(params: params);
@@ -52,7 +52,7 @@ class _MyAppState extends State<MyApp> {
   void _onRoutePushed(
     String pageName,
     String uniqueId,
-    Map<String, dynamic> params,
+    Map<dynamic, dynamic> params,
     Route<dynamic> route,
     Future<dynamic> _,
   ) {}

--- a/example/lib/simple_page_widgets.dart
+++ b/example/lib/simple_page_widgets.dart
@@ -333,7 +333,7 @@ class PlatformRouteWidget extends StatelessWidget {
 class FlutterRouteWidget extends StatefulWidget {
   const FlutterRouteWidget({this.params, this.message});
 
-  final Map<String, dynamic> params;
+  final Map<dynamic, dynamic> params;
   final String message;
 
   @override
@@ -573,7 +573,7 @@ class _FlutterRouteWidgetState extends State<FlutterRouteWidget> {
 class FragmentRouteWidget extends StatelessWidget {
   const FragmentRouteWidget(this.params);
 
-  final Map<String, dynamic> params;
+  final Map<dynamic, dynamic> params;
 
   @override
   Widget build(BuildContext context) {

--- a/example_swift/lib/main.dart
+++ b/example_swift/lib/main.dart
@@ -17,18 +17,18 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     FlutterBoost.singleton.registerPageBuilders(<String, PageBuilder>{
-      'first': (String pageName, Map<String, dynamic> params, String _) =>
+      'first': (String pageName, Map<dynamic, dynamic> params, String _) =>
           FirstRouteWidget(),
-      'second': (String pageName, Map<String, dynamic> params, String _) =>
+      'second': (String pageName, Map<dynamic, dynamic> params, String _) =>
           SecondRouteWidget(),
-      'tab': (String pageName, Map<String, dynamic> params, String _) =>
+      'tab': (String pageName, Map<dynamic, dynamic> params, String _) =>
           TabRouteWidget(),
       'flutterFragment':
-          (String pageName, Map<String, dynamic> params, String _) =>
+          (String pageName, Map<dynamic, dynamic> params, String _) =>
               FragmentRouteWidget(params),
 
       ///可以在native层通过 getContainerParams 来传递参数
-      'flutterPage': (String pageName, Map<String, dynamic> params, String _) {
+      'flutterPage': (String pageName, Map<dynamic, dynamic> params, String _) {
         print('flutterPage params:$params');
 
         return const FlutterRouteWidget();
@@ -48,7 +48,7 @@ class _MyAppState extends State<MyApp> {
   void _onRoutePushed(
     String pageName,
     String uniqueId,
-    Map<String, dynamic> params,
+    Map<dynamic, dynamic> params,
     Route<dynamic> route,
     Future<dynamic> _,
   ) {}

--- a/example_swift/lib/simple_page_widgets.dart
+++ b/example_swift/lib/simple_page_widgets.dart
@@ -169,7 +169,7 @@ class FlutterRouteWidget extends StatelessWidget {
 class FragmentRouteWidget extends StatelessWidget {
   const FragmentRouteWidget(this.params);
 
-  final Map<String, dynamic> params;
+  final Map<dynamic, dynamic> params;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/container/boost_container.dart
+++ b/lib/container/boost_container.dart
@@ -137,7 +137,7 @@ class BoostContainerState extends NavigatorState {
 
   String get name => widget.settings.name;
 
-  Map<String, dynamic> get params => widget.settings.params;
+  Map<dynamic, dynamic> get params => widget.settings.params;
 
   BoostContainerSettings get settings => widget.settings;
 
@@ -281,7 +281,7 @@ class BoostContainerSettings {
 
   final String uniqueId;
   final String name;
-  final Map<String, dynamic> params;
+  final Map<dynamic, dynamic> params;
   final WidgetBuilder builder;
 }
 

--- a/lib/container/boost_page_route.dart
+++ b/lib/container/boost_page_route.dart
@@ -40,7 +40,7 @@ class BoostPageRoute<T> extends MaterialPageRoute<T> {
 
   final String pageName;
   final String uniqueId;
-  final Map<String, dynamic> params;
+  final Map<dynamic, dynamic> params;
   final bool animated;
 
   final Set<VoidCallback> backPressedListeners = <VoidCallback>{};

--- a/lib/container/container_coordinator.dart
+++ b/lib/container/container_coordinator.dart
@@ -55,7 +55,7 @@ class ContainerCoordinator {
 
   BoostContainerSettings _createContainerSettings(
     String name,
-    Map<String, dynamic> params,
+    Map<dynamic, dynamic> params,
     String pageId,
   ) {
     Widget page;
@@ -202,7 +202,7 @@ class ContainerCoordinator {
 
   bool nativeContainerDidShow(
     String name,
-    Map<String, dynamic> params,
+    Map<dynamic, dynamic> params,
     String pageId,
   ) {
     FlutterBoost.containerManager

--- a/lib/flutter_boost.dart
+++ b/lib/flutter_boost.dart
@@ -36,15 +36,22 @@ export 'container/boost_container.dart';
 export 'container/container_manager.dart';
 
 typedef PageBuilder = Widget Function(
-    String pageName, Map<String, dynamic> params, String uniqueId);
+  String pageName,
+  Map<dynamic, dynamic> params,
+  String uniqueId,
+);
 
-typedef PrePushRoute = Route<T> Function<T>(String url, String uniqueId,
-    Map<String, dynamic> params, Route<dynamic> route);
+typedef PrePushRoute = Route<T> Function<T>(
+  String url,
+  String uniqueId,
+  Map<dynamic, dynamic> params,
+  Route<dynamic> route,
+);
 
 typedef PostPushRoute = void Function(
   String url,
   String uniqueId,
-  Map<String, dynamic> params,
+  Map<dynamic, dynamic> params,
   Route<dynamic> route,
   Future<dynamic> result,
 );

--- a/test/lib/unit/container_manager_test.dart
+++ b/test/lib/unit/container_manager_test.dart
@@ -78,9 +78,9 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     FlutterBoost.singleton.registerPageBuilders(<String, PageBuilder>{
-      'first': (String pageName, Map<String, dynamic> params, String _) =>
+      'first': (String pageName, Map<dynamic, dynamic> params, String _) =>
           FirstRouteWidget(),
-      'second': (String pageName, Map<String, dynamic> params, String _) =>
+      'second': (String pageName, Map<dynamic, dynamic> params, String _) =>
           SecondRouteWidget(),
     });
   }
@@ -123,17 +123,21 @@ void main() {
 
           FlutterBoost.singleton.registerPageBuilders(
             <String, PageBuilder>{
-              'context':
-                  (String pageName, Map<String, dynamic> params, String _) =>
-                      Builder(
-                        builder: (BuildContext context) {
-                          return FloatingActionButton(
-                            onPressed: () {
-                              builderContext = context;
-                            },
-                          );
-                        },
-                      ),
+              'context': (
+                String pageName,
+                Map<dynamic, dynamic> params,
+                String _,
+              ) {
+                return Builder(
+                  builder: (BuildContext context) {
+                    return FloatingActionButton(
+                      onPressed: () {
+                        builderContext = context;
+                      },
+                    );
+                  },
+                );
+              },
             },
           );
 
@@ -204,16 +208,21 @@ void main() {
 
           FlutterBoost.singleton.registerPageBuilders(
             <String, PageBuilder>{
-              'context': (String pageName, Map<String, dynamic> params, _) =>
-                  Builder(
-                    builder: (BuildContext context) {
-                      return FloatingActionButton(
-                        onPressed: () {
-                          builderContext = context;
-                        },
-                      );
-                    },
-                  ),
+              'context': (
+                String pageName,
+                Map<dynamic, dynamic> params,
+                String _,
+              ) {
+                return Builder(
+                  builder: (BuildContext context) {
+                    return FloatingActionButton(
+                      onPressed: () {
+                        builderContext = context;
+                      },
+                    );
+                  },
+                );
+              },
             },
           );
 
@@ -257,16 +266,21 @@ void main() {
 
         FlutterBoost.singleton.registerPageBuilders(
           <String, PageBuilder>{
-            'context': (String pageName, Map<String, dynamic> params, _) =>
-                Builder(
-                  builder: (BuildContext context) {
-                    return FloatingActionButton(
-                      onPressed: () {
-                        builderContext = context;
-                      },
-                    );
-                  },
-                ),
+            'context': (
+              String pageName,
+              Map<dynamic, dynamic> params,
+              String _,
+            ) {
+              return Builder(
+                builder: (BuildContext context) {
+                  return FloatingActionButton(
+                    onPressed: () {
+                      builderContext = context;
+                    },
+                  );
+                },
+              );
+            },
           },
         );
 

--- a/test/lib/unit/flutter_boost_test.dart
+++ b/test/lib/unit/flutter_boost_test.dart
@@ -8,8 +8,8 @@ void main() {
 
   test('test onMethodCall', () async {
     FlutterBoost.singleton.registerDefaultPageBuilder(
-        (String pageName, Map<String, dynamic> params, String _) =>
-            Container());
+      (String _, Map<dynamic, dynamic> __, String ___) => Container(),
+    );
     FlutterBoost.singleton.addContainerObserver(
       (ContainerOperation operation, BoostContainerSettings settings) {},
     );

--- a/test/lib/unit/page_widget_test.dart
+++ b/test/lib/unit/page_widget_test.dart
@@ -17,17 +17,17 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     FlutterBoost.singleton.registerPageBuilders(<String, PageBuilder>{
-      'embeded': (String pageName, Map<String, dynamic> params, _) =>
+      'embeded': (String pageName, Map<dynamic, dynamic> params, _) =>
           EmbededFirstRouteWidget(),
-      'first': (String pageName, Map<String, dynamic> params, _) =>
+      'first': (String pageName, Map<dynamic, dynamic> params, _) =>
           FirstRouteWidget(),
-      'second': (String pageName, Map<String, dynamic> params, _) =>
+      'second': (String pageName, Map<dynamic, dynamic> params, _) =>
           SecondRouteWidget(),
-      'tab': (String pageName, Map<String, dynamic> params, _) =>
+      'tab': (String pageName, Map<dynamic, dynamic> params, _) =>
           TabRouteWidget(),
-      'flutterFragment': (String pageName, Map<String, dynamic> params, _) =>
+      'flutterFragment': (String pageName, Map<dynamic, dynamic> params, _) =>
           FragmentRouteWidget(params),
-      'flutterPage': (String pageName, Map<String, dynamic> params, _) {
+      'flutterPage': (String pageName, Map<dynamic, dynamic> params, _) {
         print('flutterPage params:$params');
 
         return FlutterRouteWidget(params: params);
@@ -48,7 +48,7 @@ class _MyAppState extends State<MyApp> {
   void _onRoutePushed(
     String pageName,
     String uniqueId,
-    Map<String, dynamic> params,
+    Map<dynamic, dynamic> params,
     Route<dynamic> route,
     Future<dynamic> _,
   ) {}

--- a/test/lib/unit/page_widgets.dart
+++ b/test/lib/unit/page_widgets.dart
@@ -113,7 +113,7 @@ class TabRouteWidget extends StatelessWidget {
 class FlutterRouteWidget extends StatefulWidget {
   const FlutterRouteWidget({this.params, this.message});
 
-  final Map<String, dynamic> params;
+  final Map<dynamic, dynamic> params;
   final String message;
 
   @override
@@ -314,7 +314,7 @@ class _FlutterRouteWidgetState extends State<FlutterRouteWidget> {
 class FragmentRouteWidget extends StatelessWidget {
   const FragmentRouteWidget(this.params);
 
-  final Map<String, dynamic> params;
+  final Map<dynamic, dynamic> params;
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
This is a further implementation of #694 and #663 , the root cause is the same in #694 , which the generic type would be erased when passing through channels.

It's all about my less consideration and I take all responsibility for theses, sorry for that.