### PR TITLE
[Action Required] Test breakage due to HeroControllerScope refactor

### DIFF
--- a/lib/container/container_manager.dart
+++ b/lib/container/container_manager.dart
@@ -69,7 +69,6 @@ class ContainerManagerState extends State<BoostContainerManager> {
   final List<BoostContainer> _offstage = <BoostContainer>[];
 
   List<_ContainerOverlayEntry> _leastEntries;
-
   BoostContainer _onstage;
   bool _foreground = true;
 
@@ -158,15 +157,20 @@ class ContainerManagerState extends State<BoostContainerManager> {
       }
     }
 
-    final List<BoostContainer> containers = <BoostContainer>[];
-    containers.addAll(_offstage);
+    final List<Widget> containers = <Widget>[];
+    containers.addAll(_offstage.map<Widget>(
+      (BoostContainer container) => HeroControllerScope(
+        controller: null,
+        child: container
+      )
+    ));
 
     assert(_onstage != null, 'Should have a least one BoostContainer');
     containers.add(_onstage);
 
     _leastEntries = containers
         .map<_ContainerOverlayEntry>(
-            (BoostContainer container) => _ContainerOverlayEntry(container))
+            (Widget container) => _ContainerOverlayEntry(container))
         .toList(growable: false);
 
     overlayState.insertAll(_leastEntries);
@@ -336,7 +340,7 @@ class ContainerManagerState extends State<BoostContainerManager> {
 }
 
 class _ContainerOverlayEntry extends OverlayEntry {
-  _ContainerOverlayEntry(BoostContainer container)
+  _ContainerOverlayEntry(Widget container)
       : super(
           builder: (BuildContext ctx) => container,
           opaque: true,


### PR DESCRIPTION
Hello there,

I am from flutter team. We are currently refactoring the HeroControllerScope widget and noticing it breaks one of your test
PR https://github.com/flutter/flutter/pull/60655
test log https://api.cirrus-ci.com/v1/task/6640715738382336/logs/main.log

It turns out the current code in boost_container.dart is outdated and needed to be update. (It is already broken, and the refactor just surface it)

We would like to move away from registering hero controller through Navigator.observer, and use the HeroControllerScope instead.