### PR TITLE
Feat: Flutter 给 iOS 传值时，接收 iOS 的回调

### DIFF
--- a/example/ios/Runner/AppDelegate.m
+++ b/example/ios/Runner/AppDelegate.m
@@ -40,6 +40,11 @@
         }];
     }];
     
+    [[FlutterBoostPlugin sharedInstance] addEventListener:^(NSString *name, NSDictionary *arguments, FlutterResult result) {
+        NSLog(@"test_flutter_native_channel:name-%@,arguments-%@", name, arguments);
+        result(@{@"title": @"test_flutter_native_channel back"});
+    } forName:@"test_flutter_native_channel"];
+    
     self.window = [[UIWindow alloc] initWithFrame: [UIScreen mainScreen].bounds];
     
     

--- a/example/lib/simple_page_widgets.dart
+++ b/example/lib/simple_page_widgets.dart
@@ -13,13 +13,14 @@ class _FirstRouteWidgetState extends State<FirstRouteWidget> {
   _FirstRouteWidgetState();
 
   // flutter 侧MethodChannel配置，channel name需要和native侧一致
-  static const MethodChannel _methodChannel = MethodChannel('flutter_native_channel');
+  static const MethodChannel _methodChannel =
+      MethodChannel('flutter_native_channel');
   String _systemVersion = '';
 
   Future<dynamic> _getPlatformVersion() async {
-
     try {
-      final String result = await _methodChannel.invokeMethod('getPlatformVersion');
+      final String result =
+          await _methodChannel.invokeMethod('getPlatformVersion');
       print('getPlatformVersion:' + result);
       setState(() {
         _systemVersion = result;
@@ -27,7 +28,6 @@ class _FirstRouteWidgetState extends State<FirstRouteWidget> {
     } on PlatformException catch (e) {
       print(e.message);
     }
-
   }
 
   @override
@@ -131,9 +131,29 @@ class _FirstRouteWidgetState extends State<FirstRouteWidget> {
               },
             ),
             RaisedButton(
-              child: Text('Get system version by method channel:' + _systemVersion),
+              child: Text(
+                  'Get system version by method channel:' + _systemVersion),
               onPressed: () => _getPlatformVersion(),
             ),
+            InkWell(
+              child: Container(
+                padding: const EdgeInsets.all(8.0),
+                margin: const EdgeInsets.all(8.0),
+                color: Colors.yellow,
+                child: const Text(
+                  'flutter 调用原生，且原生返回值',
+                  style: TextStyle(fontSize: 22.0, color: Colors.black),
+                ),
+              ),
+              onTap: () async {
+                final dynamic response = await FlutterBoost.singleton.channel
+                    .sendEvent('test_flutter_native_channel', <String, dynamic>{
+                  'title': 'test flutter native channel title'
+                });
+
+                print('test_flutter_native_channel callback data: $response');
+              },
+            )
           ],
         ),
       ),
@@ -341,15 +361,15 @@ class FlutterRouteWidget extends StatefulWidget {
 }
 
 class _FlutterRouteWidgetState extends State<FlutterRouteWidget> {
-
   // flutter 侧MethodChannel配置，channel name需要和native侧一致
-  static const MethodChannel _methodChannel = MethodChannel('flutter_native_channel');
+  static const MethodChannel _methodChannel =
+      MethodChannel('flutter_native_channel');
   String _systemVersion = '';
 
   Future<dynamic> _getPlatformVersion() async {
-
     try {
-      final String result = await _methodChannel.invokeMethod('getPlatformVersion');
+      final String result =
+          await _methodChannel.invokeMethod('getPlatformVersion');
       print('getPlatformVersion:' + result);
       setState(() {
         _systemVersion = result;
@@ -357,7 +377,14 @@ class _FlutterRouteWidgetState extends State<FlutterRouteWidget> {
     } on PlatformException catch (e) {
       print(e.message);
     }
+  }
 
+  void _callNativeAndWaitResponse() {
+    final Map<String, dynamic> params = <String, dynamic>{
+      'title': 'test flutter native channel title'
+    };
+    FlutterBoost.singleton.channel
+        .sendEvent('test_flutter_native_channel', params);
   }
 
   @override

--- a/ios/Classes/Boost/FLBTypes.h
+++ b/ios/Classes/Boost/FLBTypes.h
@@ -22,12 +22,14 @@
  * THE SOFTWARE.
  */
 #import <Foundation/Foundation.h>
+#import <Flutter/Flutter.h>
 
 #ifndef FLBTypes_h
 #define FLBTypes_h
 
 typedef void (^FLBEventListener) (NSString *name ,
-                                  NSDictionary *arguments);
+                                  NSDictionary *arguments,
+                                  FlutterResult result);
 typedef void (^FLBVoidCallback)(void);
 
 #endif /* FLBTypes_h */

--- a/ios/Classes/Messaging/BoostMessageChannel.mm
+++ b/ios/Classes/Messaging/BoostMessageChannel.mm
@@ -77,7 +77,7 @@
             NSMutableArray *list = [self lists][name];
             if(list){
                 for(FLBEventListener l in list){
-                    l(name,arguments);
+                    l(name,arguments, result);
                 }
             }
         }

--- a/lib/channel/boost_channel.dart
+++ b/lib/channel/boost_channel.dart
@@ -62,17 +62,26 @@ class BoostChannel {
       <String, List<EventListener>>{};
   final Set<MethodHandler> _methodHandlers = <MethodHandler>{};
 
-  void sendEvent(String name, Map<String, dynamic> arguments) {
-    if (name == null) {
-      return;
-    }
+//  void sendEvent(String name, Map<String, dynamic> arguments) {
+//    if (name == null) {
+//      return;
+//    }
+//
+//    arguments ??= <String, dynamic>{};
+//
+//    final Map<String, dynamic> msg = <String, dynamic>{};
+//    msg['name'] = name;
+//    msg['arguments'] = arguments;
+//    _methodChannel.invokeMethod<dynamic>('__event__', msg);
+//  }
 
+  Future<dynamic> sendEvent(String name, Map<String, dynamic> arguments) {
+    assert(name != null);
     arguments ??= <String, dynamic>{};
-
     final Map<String, dynamic> msg = <String, dynamic>{};
     msg['name'] = name;
     msg['arguments'] = arguments;
-    _methodChannel.invokeMethod<dynamic>('__event__', msg);
+    return _methodChannel.invokeMethod<dynamic>('__event__', msg);
   }
 
   Future<T> invokeMethod<T>(String method, [dynamic arguments]) async {

--- a/lib/flutter_boost.dart
+++ b/lib/flutter_boost.dart
@@ -63,8 +63,6 @@ class FlutterBoost {
   final ObserversHolder _observersHolder = ObserversHolder();
   final BoostChannel _boostChannel = BoostChannel();
 
-
-
   static ContainerManagerState get containerManager =>
       _instance.containerManagerKey.currentState;
 
@@ -77,7 +75,11 @@ class FlutterBoost {
             pageInfo.containsKey("params") &&
             pageInfo.containsKey("uniqueId")) {
           ContainerCoordinator.singleton.nativeContainerDidShow(
-              pageInfo["name"], pageInfo["params"], pageInfo["uniqueId"]);
+            pageInfo["name"] as String,
+            Map<String, dynamic>.from(
+                pageInfo['params'] as Map<dynamic, dynamic>),
+            pageInfo["uniqueId"] as String,
+          );
         }
       });
     });


### PR DESCRIPTION
flutter 端：

```dart
final dynamic response = await FlutterBoost.singleton.channel
       .sendEvent('test_flutter_native_channel', <String, dynamic>{
             'title': 'test flutter native channel title'
       });
print('test_flutter_native_channel callback data: $response');
```

iOS 端：

```objc
[[FlutterBoostPlugin sharedInstance] addEventListener:^(NSString *name, NSDictionary *arguments, FlutterResult result) {
        NSLog(@"test_flutter_native_channel:name-%@,arguments-%@", name, arguments);

        // 回调给 flutter
        result(@{@"title": @"test_flutter_native_channel back"});
} forName:@"test_flutter_native_channel"];
```
