### PR TITLE
修复控制针问题

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/XPlatformPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/XPlatformPlugin.java
@@ -151,7 +151,7 @@ public class XPlatformPlugin {
 
     @SuppressWarnings("deprecation")
     private void setSystemChromeApplicationSwitcherDescription(PlatformChannel.AppSwitcherDescription description) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || activity == null) {
             return;
         }
 


### PR DESCRIPTION

修复启动后titlewidget 设置 taskdescripion ,xplatformplugin 内部的activity为空导致的PlatformException(error, Attempt to invoke virtual method 'void android.app.Activity.setTaskDescription(android.app.ActivityManager$TaskDescription)' on a null object reference, null)


Signed-off-by: 程建超 <chengjianchao@jd.com>