### PR TITLE
iOS：大幅减少回退页面闪动的几率

### DIFF
--- a/ios/Classes/container/FLBFlutterViewContainer.m
+++ b/ios/Classes/container/FLBFlutterViewContainer.m
@@ -284,7 +284,9 @@ static NSUInteger kInstanceCounter = 0;
     //https://github.com/flutter/engine/pull/18742
     if([UIApplication sharedApplication].applicationState == UIApplicationStateActive){
         //NOTES：务必在show之后再update，否则有闪烁; 或导致侧滑返回时上一个页面会和top页面内容一样
-        [self surfaceUpdated:YES];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            [self surfaceUpdated:YES];
+        });
     }
     
     [super viewDidAppear:animated];


### PR DESCRIPTION
大佬们，瞅一眼呗，_不希望合并此分支_，如果不提 pr, **Can't catch your eye**，当然有个问题抛出来：

**为什么延迟 0.5s 后，页面回退就不闪动了。**

_延迟 0.5s 的后，打开一个新的也页面，也会出闪动_。😿！

 应该需要要搞个时序图，当然**娃是你们生出来的**，应该会理的非常清晰。
