### PR TITLE
解决iOS启动第一次打开Flutter页面白屏

### DIFF
--- a/lib/flutter_boost.dart
+++ b/lib/flutter_boost.dart
@@ -71,7 +71,8 @@ class FlutterBoost {
       singleton.channel
           .invokeMethod<Map<dynamic, dynamic>>('pageOnStart')
           .then((Map<dynamic, dynamic> _pageInfo) {
-        final Map<String, dynamic> pageInfo = _pageInfo?.cast<String, dynamic>();
+        final Map<String, dynamic> pageInfo =
+            _pageInfo?.cast<String, dynamic>();
         if (pageInfo?.isEmpty ?? true) {
           return;
         }
@@ -94,18 +95,11 @@ class FlutterBoost {
     PrePushRoute prePush,
     PostPushRoute postPush,
   }) {
-    if (Platform.isAndroid) {
-      onPageStart();
-    } else if (Platform.isIOS) {
-      // TODO(AlexVincent525): 未解之谜
-      assert(() {
-        () async {
-          onPageStart();
-        }();
-        return true;
-      }());
-    }
-
+    // 1、methodChannel didShowPageContainer 在启动的时候可能不可靠，引擎刚启动method channel可能发不到dart
+    // 2、Flutter 1.22之后 rootIsolate启动是异步的， methodChannel didShowPageContainer 发到dart时可能main函数还没跑完，
+    //    此时flutter_boost还没初始化完成，路由切换失败，导致白屏。
+    // 所以需要boost启动后主动取一次路由信息
+    onPageStart();
     return (BuildContext context, Widget child) {
       assert(child is Navigator, 'child must be Navigator, what is wrong?');
 


### PR DESCRIPTION
1、methodChannel didShowPageContainer 在启动的时候可能不可靠，引擎刚启动method channel可能发不到dart
2、Flutter 1.22之后 rootIsolate启动是异步的， methodChannel didShowPageContainer 发到dart时可能main函数还没跑完，
     此时flutter_boost还没初始化完成，路由切换失败，导致白屏。
所以需要boost启动后主动取一次路由信息