### PR TITLE
修复StackInfo.decode出现的NoSuchMethodError异常

### DIFF
--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -41,7 +41,7 @@ class StackInfo {
   }
 
   static StackInfo decode(Object message) {
-    final Map<Object, Object> pigeonMap = message as Map<Object, Object>;
+    final Map<Object, Object> pigeonMap = message ?? <Object, Object>{};
     return StackInfo()
       ..containers = pigeonMap['containers'] as List<Object>
       ..routes = pigeonMap['routes'] as Map<Object, Object>;


### PR DESCRIPTION
[NativeRouterApi.getStackFromHost -> StackInfo.decode 出现NoSuchMethodError异常](https://github.com/alibaba/flutter_boost/issues/1025)