### PR TITLE
修复iOS端由原生打开flutter页面，再关闭flutter页面时，container容器不能按时dealloc的问题，以及提供全局路由监听的能力

### DIFF
--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -228,6 +228,11 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)detatchFlutterEngine
 {
+    //need to call [surfaceUpdated:NO] to detach the view controller's ref from
+    //interal engine platformViewController,or dealloc will not be called after controller close.
+    //detail:https://github.com/flutter/engine/blob/07e2520d5d8f837da439317adab4ecd7bff2f72d/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm#L529
+    [self surfaceUpdated:NO];
+    
     if(ENGINE.viewController != nil) {
         ENGINE.viewController = nil;
     }

--- a/lib/page_visibility.dart
+++ b/lib/page_visibility.dart
@@ -1,19 +1,40 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_boost/logger.dart';
 
+///observer for all pages visibility
+abstract class GlobalPageVisiblityObserver {
+  void onPageCreate(Route<dynamic> route);
+
+  void onPageShow(Route<dynamic> route, {bool isForegroundEvent = false});
+
+  void onPageHide(Route<dynamic> route, {bool isBackgroundEvent = false});
+
+  void onPageDestroy(Route<dynamic> route);
+}
+
+///observer for single page visibility
 abstract class PageVisibilityObserver {
   void onPageCreate();
+
   void onPageShow({bool isForegroundEvent});
+
   void onPageHide({bool isBackgroundEvent});
+
   void onPageDestroy();
 }
 
 class PageVisibilityBinding {
   PageVisibilityBinding._();
+
   static final PageVisibilityBinding instance = PageVisibilityBinding._();
 
+  ///listeners for single page event
   final Map<Route<dynamic>, Set<PageVisibilityObserver>> _listeners =
       <Route<dynamic>, Set<PageVisibilityObserver>>{};
+
+  ///listeners for all pages event
+  final Set<GlobalPageVisiblityObserver> _globalListeners =
+      <GlobalPageVisiblityObserver>{};
 
   /// Registers the given object and route as a binding observer.
   void addObserver(PageVisibilityObserver observer, Route<dynamic> route) {
@@ -23,7 +44,9 @@ class PageVisibilityBinding {
         _listeners.putIfAbsent(route, () => <PageVisibilityObserver>{});
     if (observers.add(observer)) {
       observer.onPageCreate();
+      dispatchGlobalCreateEvent(route);
       observer.onPageShow();
+      dispatchGlobalPageShowEvent(route);
     }
     Logger.log(
         'page_visibility, #addObserver, $observers, ${route.settings.name}');
@@ -37,6 +60,23 @@ class PageVisibilityBinding {
       observers?.remove(observer);
     }
     Logger.log('page_visibility, #removeObserver, $observer');
+  }
+
+  ///Register [observer] to [_globalListeners] set
+  void addGlobalObserver(GlobalPageVisiblityObserver observer) {
+    assert(observer != null);
+    _globalListeners.add(observer);
+
+    Logger.log('page_visibility, #addGlobalObserver, $observer');
+  }
+
+  ///Register [observer] from [_globalListeners] set
+  void removeGlobalObserver(GlobalPageVisiblityObserver observer) {
+    assert(observer != null);
+
+    _globalListeners.remove(observer);
+
+    Logger.log('page_visibility, #removeGlobalObserver, $observer');
   }
 
   void dispatchPageShowEvent(Route<dynamic> route) {
@@ -56,6 +96,8 @@ class PageVisibilityBinding {
     }
     Logger.log(
         'page_visibility, #dispatchPageShowEvent, ${route.settings.name}');
+
+    dispatchGlobalPageShowEvent(route);
   }
 
   void dispatchPageHideEvent(Route<dynamic> route) {
@@ -75,6 +117,8 @@ class PageVisibilityBinding {
     }
     Logger.log(
         'page_visibility, #dispatchPageHideEvent, ${route.settings.name}');
+
+    dispatchGlobalPageHideEvent(route);
   }
 
   void dispatchPageDestoryEvent(Route<dynamic> route) {
@@ -92,8 +136,11 @@ class PageVisibilityBinding {
         }
       }
     }
+
     Logger.log(
         'page_visibility, #dispatchPageDestoryEvent, ${route.settings.name}');
+
+    dispatchGlobalPageDestroyEvent(route);
   }
 
   void dispatchBackgroundEvent(Route<dynamic> route) {
@@ -113,6 +160,8 @@ class PageVisibilityBinding {
     }
     Logger.log(
         'page_visibility, #dispatchBackgroundEvent, ${route.settings.name}');
+
+    dispatchGlobalPageHideEvent(route, isBackgroundEvent: true);
   }
 
   void dispatchForegroundEvent(Route<dynamic> route) {
@@ -132,5 +181,69 @@ class PageVisibilityBinding {
     }
     Logger.log(
         'page_visibility, #dispatchForegroundEvent, ${route.settings.name}');
+    dispatchGlobalPageShowEvent(route, isForegroundEvent: true);
+  }
+
+  void dispatchGlobalCreateEvent(Route<dynamic> route) {
+    if (route == null) {
+      return;
+    }
+    final List<GlobalPageVisiblityObserver> globalObserversList =
+        _globalListeners.toList();
+
+    for (GlobalPageVisiblityObserver observer in globalObserversList) {
+      observer.onPageCreate(route);
+    }
+
+    Logger.log(
+        'page_visibility, #dispatchGlobalCreateEvent, ${route.settings.name}');
+  }
+
+  void dispatchGlobalPageShowEvent(Route<dynamic> route,
+      {bool isForegroundEvent = false}) {
+    if (route == null) {
+      return;
+    }
+    final List<GlobalPageVisiblityObserver> globalObserversList =
+        _globalListeners.toList();
+
+    for (GlobalPageVisiblityObserver observer in globalObserversList) {
+      observer.onPageShow(route, isForegroundEvent: isForegroundEvent);
+    }
+
+    Logger.log(
+        'page_visibility, #dispatchGlobalPageShowEvent, ${route.settings.name}');
+  }
+
+  void dispatchGlobalPageHideEvent(Route<dynamic> route,
+      {bool isBackgroundEvent = false}) {
+    if (route == null) {
+      return;
+    }
+    final List<GlobalPageVisiblityObserver> globalObserversList =
+        _globalListeners.toList();
+
+    for (GlobalPageVisiblityObserver observer in globalObserversList) {
+      observer.onPageHide(route, isBackgroundEvent: isBackgroundEvent);
+    }
+
+    Logger.log(
+        'page_visibility, #dispatchGlobalPageHideEvent, ${route.settings.name}');
+  }
+
+  void dispatchGlobalPageDestroyEvent(Route<dynamic> route,
+      {bool isBackgroundEvent = false}) {
+    if (route == null) {
+      return;
+    }
+    final List<GlobalPageVisiblityObserver> globalObserversList =
+        _globalListeners.toList();
+
+    for (GlobalPageVisiblityObserver observer in globalObserversList) {
+      observer.onPageDestroy(route);
+    }
+
+    Logger.log(
+        'page_visibility, #dispatchGlobalPageDestroyEvent, ${route.settings.name}');
   }
 }


### PR DESCRIPTION
关联的issue:https://github.com/alibaba/flutter_boost/issues/1047

备注:
根据[引擎源码](https://github.com/flutter/engine/blob/07e2520d5d8f837da439317adab4ecd7bff2f72d/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm#L518)来看，内部的`surfaceUpdated`方法在传递`appeared`为true时，会持有当前vc，传入为false的时候会将各个属性置nil,之前发现页面退出的时候没有立刻dealloc，是因为内部还持有本vc的引用，所以无法释放，所以在detachEngine的方法中，先叫一遍`[self.surfaceUpdated:NO]`,释放引用，测试下来vc可以按时dealloc，但是由于`surfaceUpdated`方法可能会引起其他问题，我目前还分析不出，请各位看看有没有什么问题