### PR TITLE
[iOS]提供从原生页面回传参数到flutter侧的能力

### DIFF
--- a/example/ios/Runner/ReturnDataViewConntroller.h
+++ b/example/ios/Runner/ReturnDataViewConntroller.h
@@ -1,0 +1,17 @@
+//
+//  ReturnDataViewConntroller.h
+//  Runner
+//
+//  Created by luckysmg on 2021/5/1.
+//  Copyright © 2021 The Chromium Authors. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import <UIKit/UIKit.h>
+
+@interface ReturnDataViewConntroller : UIViewController
+
+@end
+
+

--- a/example/ios/Runner/ReturnDataViewConntroller.m
+++ b/example/ios/Runner/ReturnDataViewConntroller.m
@@ -29,7 +29,7 @@
 -(void) onTap{
     NSDictionary *dic = [NSDictionary dictionaryWithObject:@"zhangsan" forKey:@"zs"];
     
-    [[FlutterBoost instance]sendResultToFlutterWithPageName:@"NativeReturnDataPage" arugments:dic];
+    [[FlutterBoost instance]sendResultToFlutterWithPageName:@"NativeReturnDataPage" arguments:dic];
 }
 
 

--- a/example/ios/Runner/ReturnDataViewConntroller.m
+++ b/example/ios/Runner/ReturnDataViewConntroller.m
@@ -1,0 +1,36 @@
+//
+//  ReturnDataViewConntroller.m
+//  Runner
+//
+//  Created by luckysmg on 2021/5/1.
+//  Copyright © 2021 The Chromium Authors. All rights reserved.
+//
+
+#import "ReturnDataViewConntroller.h"
+#import <flutter_boost/FlutterBoost.h>
+
+@implementation ReturnDataViewConntroller
+
+- (void)viewDidLoad{
+    [super viewDidLoad];
+    self.view.backgroundColor = UIColor.whiteColor;
+    
+    UIButton* button = [[UIButton alloc]init];
+    [button addTarget:self action:@selector(onTap) forControlEvents:UIControlEventTouchUpInside];
+    [button setTitle:@"tap to return data " forState:UIControlStateNormal];
+    [button setTitleColor:UIColor.blackColor forState:UIControlStateNormal];
+    
+    [self.view addSubview:button];
+    button.frame = CGRectMake(150, 400, 50, 300);
+    [button sizeToFit];
+
+}
+
+-(void) onTap{
+    
+    NSDictionary *dic = [NSDictionary dictionaryWithObject:@"zhangsan" forKey:@"zs"];
+    [FlutterBoost.instance setResult:dic pageName:@"NativeReturnDataPage"];
+}
+
+
+@end

--- a/example/ios/Runner/ReturnDataViewConntroller.m
+++ b/example/ios/Runner/ReturnDataViewConntroller.m
@@ -27,9 +27,9 @@
 }
 
 -(void) onTap{
-    
     NSDictionary *dic = [NSDictionary dictionaryWithObject:@"zhangsan" forKey:@"zs"];
-    [FlutterBoost.instance setResult:dic pageName:@"NativeReturnDataPage"];
+    
+    [[FlutterBoost instance]sendResultToFlutterWithPageName:@"NativeReturnDataPage" arugments:dic];
 }
 
 

--- a/ios/Classes/FlutterBoost.h
+++ b/ios/Classes/FlutterBoost.h
@@ -78,7 +78,7 @@
 /// 将原生页面的数据回传到flutter侧的页面的的方法
 /// @param pageName 这个页面在路由表中的名字，和flutter侧BoostNavigator.push(name)中的name一样
 /// @param arguments 你想传的参数
-- (void)sendResultToFlutterWithPageName:(NSString*)pageName arugments:(NSDictionary*) arguments;
+- (void)sendResultToFlutterWithPageName:(NSString*)pageName arguments:(NSDictionary*) arguments;
 
 @end
 

--- a/ios/Classes/FlutterBoost.h
+++ b/ios/Classes/FlutterBoost.h
@@ -75,5 +75,11 @@
    arguments:(NSDictionary *)arguments;
 
 
+/// 将结果回传到flutter侧的页面的的方法
+/// @param arguments 参数
+/// @param pageName 这个页面在路由表中的名字，和flutter侧BoostNavigator.push(name)中的name一样
+- (void)setResult:(NSDictionary *)arguments pageName:(NSString*) pageName;
+
+
 @end
 

--- a/ios/Classes/FlutterBoost.h
+++ b/ios/Classes/FlutterBoost.h
@@ -75,11 +75,10 @@
    arguments:(NSDictionary *)arguments;
 
 
-/// 将结果回传到flutter侧的页面的的方法
-/// @param arguments 参数
+/// 将原生页面的数据回传到flutter侧的页面的的方法
 /// @param pageName 这个页面在路由表中的名字，和flutter侧BoostNavigator.push(name)中的name一样
-- (void)setResult:(NSDictionary *)arguments pageName:(NSString*) pageName;
-
+/// @param arguments 你想传的参数
+- (void)sendResultToFlutterWithPageName:(NSString*)pageName arugments:(NSDictionary*) arguments;
 
 @end
 

--- a/ios/Classes/FlutterBoost.m
+++ b/ios/Classes/FlutterBoost.m
@@ -113,11 +113,20 @@
 - (void)close:(NSString *)uniqueId {
     FBCommonParams* params = [[FBCommonParams alloc] init];
     params.uniqueId=uniqueId;
-    
     [self.plugin.flutterApi popRoute:params completion:^(NSError* error) {
     } ];
-    
 }
+
+- (void)setResult:(NSDictionary *)arguments pageName:(NSString*) pageName {
+    FBCommonParams* params = [[FBCommonParams alloc] init];
+    params.pageName = pageName;
+    params.arguments = arguments;
+
+    [self.plugin.flutterApi onNativeResult:params completion:^(NSError * error) {
+        
+    }];
+}
+
 
 - (void)applicationDidEnterBackground:(UIApplication *)application {
     FBCommonParams* params = [[FBCommonParams alloc] init];

--- a/ios/Classes/FlutterBoost.m
+++ b/ios/Classes/FlutterBoost.m
@@ -117,7 +117,7 @@
     } ];
 }
 
-- (void)setResult:(NSDictionary *)arguments pageName:(NSString*) pageName {
+- (void)sendResultToFlutterWithPageName:(NSString*)pageName arguments:(NSDictionary*) arguments{
     FBCommonParams* params = [[FBCommonParams alloc] init];
     params.pageName = pageName;
     params.arguments = arguments;


### PR DESCRIPTION
由于iOS端没有Android端的setResult接口，所以在boost单例上开了一个接口用于在原生端回传flutter参数