### PR TITLE
解决在push和pop的时候，页面栈所有页面重复build的问题

### DIFF
--- a/lib/flutter_boost.dart
+++ b/lib/flutter_boost.dart
@@ -1,6 +1,7 @@
 
 export 'boost_container.dart';
 export 'boost_flutter_router_api.dart';
+export 'boost_interceptor.dart';
 export 'boost_lifecycle_binding.dart';
 export 'boost_navigator.dart';
 export 'flutter_boost_app.dart';

--- a/lib/overlay_entry.dart
+++ b/lib/overlay_entry.dart
@@ -1,11 +1,82 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_boost/boost_container.dart';
 
 final GlobalKey<OverlayState> overlayKey = GlobalKey<OverlayState>();
-List<_ContainerOverlayEntry> _lastEntries;
+List<_ContainerOverlayEntry> _lastEntries = <_ContainerOverlayEntry>[];
 
-void refreshOverlayEntries(List<BoostContainer> containers) {
+///The Entry refresh mode,which indicates different situation
+enum BoostSpecificEntryRefreshMode {
+  ///Just add an new entry
+  add,
+
+  ///remove a specific entry from entries list
+  remove,
+
+  ///move an existing entry to top
+  moveToTop,
+}
+
+///Refresh an specific entry instead of all of entries to enhance the performace
+///
+///[container] : The container you want to operate,it is related with internal [OverlayEntry]
+///[mode] : The [BoostSpecificEntryRefreshMode] you want to choose
+void refreshSpecificOverlayEntries(
+    BoostContainer container, BoostSpecificEntryRefreshMode mode) {
+  //Get OverlayState from global key
+  final OverlayState overlayState = overlayKey.currentState;
+  if (overlayState == null) {
+    return;
+  }
+
+  final bool hasScheduledFrame = SchedulerBinding.instance.hasScheduledFrame;
+  final bool framesEnabled = SchedulerBinding.instance.framesEnabled;
+
+  //deal with different situation
+  switch (mode) {
+    case BoostSpecificEntryRefreshMode.add:
+      final _ContainerOverlayEntry entry = _ContainerOverlayEntry(container);
+      _lastEntries.add(entry);
+      overlayState.insert(entry);
+      break;
+    case BoostSpecificEntryRefreshMode.remove:
+      if (_lastEntries.isNotEmpty) {
+        //Find the entry matching the container
+        final _ContainerOverlayEntry entryToRemove =
+            _lastEntries.singleWhere((_ContainerOverlayEntry element) {
+          return element.containerUniqueId == container.pageInfo.uniqueId;
+        });
+
+        //remove from the list and overlay
+        _lastEntries.remove(entryToRemove);
+        entryToRemove.remove();
+      }
+      break;
+    case BoostSpecificEntryRefreshMode.moveToTop:
+      final _ContainerOverlayEntry existingEntry =
+          _lastEntries.singleWhere((_ContainerOverlayEntry element) {
+        return element.containerUniqueId == container.pageInfo.uniqueId;
+      });
+      //remove the entry from list and overlay
+      //and insert it to list'top and overlay 's top
+      _lastEntries.remove(existingEntry);
+      _lastEntries.add(existingEntry);
+      existingEntry.remove();
+      overlayState.insert(existingEntry);
+      break;
+  }
+
+  // https://github.com/alibaba/flutter_boost/issues/1056
+  // Ensure this frame is refreshed after schedule frame，otherwise the PageState.dispose may not be called
+  if (hasScheduledFrame || !framesEnabled) {
+    SchedulerBinding.instance.scheduleWarmUpFrame();
+  }
+}
+
+///Refresh all of overlayEntries
+void refreshAllOverlayEntries(List<BoostContainer> containers) {
   final OverlayState overlayState = overlayKey.currentState;
   if (overlayState == null) {
     return;
@@ -20,7 +91,7 @@ void refreshOverlayEntries(List<BoostContainer> containers) {
   _lastEntries = containers
       .map<_ContainerOverlayEntry>(
           (BoostContainer container) => _ContainerOverlayEntry(container))
-      .toList(growable: false);
+      .toList(growable: true);
 
   final bool hasScheduledFrame = SchedulerBinding.instance.hasScheduledFrame;
   final bool framesEnabled = SchedulerBinding.instance.framesEnabled;
@@ -36,21 +107,20 @@ void refreshOverlayEntries(List<BoostContainer> containers) {
 
 class _ContainerOverlayEntry extends OverlayEntry {
   _ContainerOverlayEntry(BoostContainer container)
-      : super(
+      : containerUniqueId = container.pageInfo.uniqueId,
+        super(
             builder: (BuildContext ctx) => container,
-            opaque: true,
+
+            ///Why the "opaque" is false and "maintainState" is true ? ?
+            ///reason video link:  https://www.youtube.com/watch?v=Ya3k828Brt4
+            opaque: false,
             maintainState: true);
-  bool _removed = false;
+
+  ///This overlay's id,which is the same as the it's related container
+  final String containerUniqueId;
 
   @override
-  void remove() {
-    assert(!_removed);
-
-    if (_removed) {
-      return;
-    }
-
-    _removed = true;
-    super.remove();
+  String toString() {
+    return '_ContainerOverlayEntry: containerId:$containerUniqueId';
   }
 }


### PR DESCRIPTION
1.由于每次push和pop都会build页面栈中所有页面，第一个原因是因为每次refresh都会将所有entry移除再添加，所以会造成重复的页面内所有页面重复build。
2.进行单独的添加和移除后，页面栈内的页面不会重复build，但是仍然会造成顶部的两个页面重复build的情况，也就是A push B，A也会build一次的情况，所以这里给一个链接 ：[https://www.youtube.com/watch?v=Ya3k828Brt4
](解决思路相关链接)，需要将内部overlayEntry的opaque属性设为false，因为官方的路由中有蒙层，而我们没有，而MaterialPageRoute等路由中的opaque属性是在路由动画结束后赋值给蒙层overlayEntry而不是页面overlayEntry的，所以opaque置为false之后，整个逻辑就和flutter自带的相同了