### PR TITLE
[android] FlutterBoostFragment优化

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostUtils.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostUtils.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -14,7 +15,7 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin;
  */
 public class FlutterBoostUtils {
   public static String createUniqueId(String name) {
-    return System.currentTimeMillis() + "_" + name;
+    return UUID.randomUUID().toString() + "_" + name;
   }
 
   public static FlutterBoostPlugin getPlugin(FlutterEngine engine) {

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -14,7 +14,6 @@ import com.idlefish.flutterboost.FlutterBoostUtils;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import io.flutter.embedding.android.FlutterFragment;
 import io.flutter.embedding.android.FlutterView;
@@ -172,6 +171,9 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
 
     @Override
     public String getUrl() {
+        if (!getArguments().containsKey(EXTRA_URL)) {
+            throw new RuntimeException("Oops! The fragment url are *MISSED*!");
+        }
         return getArguments().getString(EXTRA_URL);
     }
 
@@ -182,6 +184,10 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
 
     @Override
     public String getUniqueId() {
+        if (!getArguments().containsKey(EXTRA_UNIQUE_ID)) {
+            // set default uniqueId
+            getArguments().putString(EXTRA_UNIQUE_ID, FlutterBoostUtils.createUniqueId(getUrl()));
+        }
         return getArguments().getString(EXTRA_UNIQUE_ID);
     }
 

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -172,7 +172,8 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     @Override
     public String getUrl() {
         if (!getArguments().containsKey(EXTRA_URL)) {
-            throw new RuntimeException("Oops! The fragment url are *MISSED*!");
+            throw new RuntimeException("Oops! The fragment url are *MISSED*! You should "
+                    + "override the |getUrl|, or set url via CachedEngineFragmentBuilder.");
         }
         return getArguments().getString(EXTRA_URL);
     }

--- a/lib/boost_container.dart
+++ b/lib/boost_container.dart
@@ -52,8 +52,8 @@ class BoostContainerWidget extends StatefulWidget {
   // ignore: invalid_override_of_non_virtual_member
   bool operator ==(Object other) {
     if (other is BoostContainerWidget) {
-      BoostContainerWidget otherWidget = other;
-      return this.container.pageInfo.uniqueId ==
+      var otherWidget = other;
+      return container.pageInfo.uniqueId ==
           otherWidget.container.pageInfo.uniqueId;
     }
     return super == other;

--- a/lib/boost_lifecycle_binding.dart
+++ b/lib/boost_lifecycle_binding.dart
@@ -32,7 +32,7 @@ class BoostLifecycleBinding {
   void containerDidHide(BoostContainer container) {
     Logger.log('boost_lifecycle: BoostLifecycleBinding.containerDidHide');
     PageVisibilityBinding.instance
-        .dispatchPageHideEvent(container?.topPage.route);
+        .dispatchPageHideEvent(container?.topPage?.route);
   }
 
   void routeDidPush(Route<dynamic> route, Route<dynamic> previousRoute) {

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import 'boost_container.dart';
@@ -324,9 +323,8 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
       refreshOnRemove(container);
     } else {
       for (var container in containers) {
-
         final page = container.pages.singleWhere(
-                (entry) => entry.pageInfo.uniqueId == uniqueId,
+            (entry) => entry.pageInfo.uniqueId == uniqueId,
             orElse: () => null);
 
         if (page != null) {

--- a/lib/page_visibility.dart
+++ b/lib/page_visibility.dart
@@ -203,8 +203,8 @@ class PageVisibilityBinding {
       }
     }
 
-    Logger.log(
-        'page_visibility, #dispatchPageBackgroundEvent, ${route.settings.name}');
+    Logger.log('page_visibility, '
+        '#dispatchPageBackgroundEvent, ${route.settings.name}');
 
     dispatchGlobalBackgroundEvent(route);
   }


### PR DESCRIPTION
1. 业务同时创建多个FlutterBoostFragment时，uniqueId可能重复，使用UUID替代时间戳
2. 业务可能不通过CachedEngineFragmentBuilder创建FlutterBoostFragment，提供uniqueId默认实现