### PR TITLE
支持后台页面预渲染

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -107,11 +107,17 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
 
     public void pushRoute(String uniqueId, String pageName, Map<String, Object> arguments,
                           final Reply<Void> callback) {
+        pushRoute(uniqueId, pageName, arguments, false, callback);
+    }
+
+    public void pushRoute(String uniqueId, String pageName, Map<String, Object> arguments, boolean beforehand,
+                          final Reply<Void> callback) {
         if (channel != null) {
             Messages.CommonParams params = new Messages.CommonParams();
             params.setUniqueId(uniqueId);
             params.setPageName(pageName);
             params.setArguments((Map<Object, Object>)(Object) arguments);
+            params.setBeforehand(beforehand);
             channel.pushRoute(params, reply -> {
                 if (callback != null) {
                     callback.reply(null);
@@ -193,6 +199,7 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
     }
 
     public void onContainerCreated(FlutterViewContainer container) {
+        pushRoute(container.getUniqueId(), getUrl(), getUrlParams(), true/*preRender*/, null);
         Log.v(TAG, "#onContainerCreated: " + container.getUniqueId());
     }
 

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -110,14 +110,14 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
         pushRoute(uniqueId, pageName, arguments, false, callback);
     }
 
-    public void pushRoute(String uniqueId, String pageName, Map<String, Object> arguments, boolean beforehand,
+    public void pushRoute(String uniqueId, String pageName, Map<String, Object> arguments, boolean preRender,
                           final Reply<Void> callback) {
         if (channel != null) {
             Messages.CommonParams params = new Messages.CommonParams();
             params.setUniqueId(uniqueId);
             params.setPageName(pageName);
             params.setArguments((Map<Object, Object>)(Object) arguments);
-            params.setBeforehand(beforehand);
+            params.setPreRender(preRender);
             channel.pushRoute(params, reply -> {
                 if (callback != null) {
                     callback.reply(null);

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -199,7 +199,7 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
     }
 
     public void onContainerCreated(FlutterViewContainer container) {
-        pushRoute(container.getUniqueId(), getUrl(), getUrlParams(), true/*preRender*/, null);
+        pushRoute(container.getUniqueId(), container.getUrl(), container.getUrlParams(), true/*preRender*/, null);
         Log.v(TAG, "#onContainerCreated: " + container.getUniqueId());
     }
 

--- a/android/src/main/java/com/idlefish/flutterboost/Messages.java
+++ b/android/src/main/java/com/idlefish/flutterboost/Messages.java
@@ -32,9 +32,9 @@ public class Messages {
     public Boolean getOpaque() { return opaque; }
     public void setOpaque(Boolean setterArg) { this.opaque = setterArg; }
 
-    private Boolean beforehand;
-    public Boolean getBeforehand() { return beforehand; }
-    public void setBeforehand(Boolean setterArg) { this.beforehand = setterArg; }
+    private Boolean preRender;
+    public Boolean getPreRender() { return preRender; }
+    public void setPreRender(Boolean setterArg) { this.preRender = setterArg; }
 
     Map<String, Object> toMap() {
       Map<String, Object> toMapResult = new HashMap<>();
@@ -42,7 +42,7 @@ public class Messages {
       toMapResult.put("uniqueId", uniqueId);
       toMapResult.put("arguments", arguments);
       toMapResult.put("opaque", opaque);
-      toMapResult.put("beforehand", beforehand);
+      toMapResult.put("preRender", preRender);
       return toMapResult;
     }
     static CommonParams fromMap(Map<String, Object> map) {
@@ -55,8 +55,8 @@ public class Messages {
       fromMapResult.arguments = (Map<Object, Object>)arguments;
       Object opaque = map.get("opaque");
       fromMapResult.opaque = (Boolean)opaque;
-      Object beforehand = map.get("beforehand");
-      fromMapResult.beforehand = (Boolean)beforehand;
+      Object preRender = map.get("preRender");
+      fromMapResult.preRender = (Boolean)preRender;
       return fromMapResult;
     }
   }

--- a/android/src/main/java/com/idlefish/flutterboost/Messages.java
+++ b/android/src/main/java/com/idlefish/flutterboost/Messages.java
@@ -32,12 +32,17 @@ public class Messages {
     public Boolean getOpaque() { return opaque; }
     public void setOpaque(Boolean setterArg) { this.opaque = setterArg; }
 
+    private Boolean beforehand;
+    public Boolean getBeforehand() { return beforehand; }
+    public void setBeforehand(Boolean setterArg) { this.beforehand = setterArg; }
+
     Map<String, Object> toMap() {
       Map<String, Object> toMapResult = new HashMap<>();
       toMapResult.put("pageName", pageName);
       toMapResult.put("uniqueId", uniqueId);
       toMapResult.put("arguments", arguments);
       toMapResult.put("opaque", opaque);
+      toMapResult.put("beforehand", beforehand);
       return toMapResult;
     }
     static CommonParams fromMap(Map<String, Object> map) {
@@ -50,6 +55,8 @@ public class Messages {
       fromMapResult.arguments = (Map<Object, Object>)arguments;
       Object opaque = map.get("opaque");
       fromMapResult.opaque = (Boolean)opaque;
+      Object beforehand = map.get("beforehand");
+      fromMapResult.beforehand = (Boolean)beforehand;
       return fromMapResult;
     }
   }

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/MainActivity.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/MainActivity.java
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.idlefish.flutterboost.FlutterBoost;
 import com.idlefish.flutterboost.containers.FlutterBoostActivity;
+import com.idlefish.flutterboost.containers.FlutterBoostView;
 
 import java.lang.ref.WeakReference;
 import java.util.HashMap;
@@ -28,6 +29,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private TextView mOpenFlutter;
     private TextView mOpenFlutterFragment;
     private TextView mOpenCustomViewTab;
+    private TextView mWarmUpCustomViewTab;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -41,11 +43,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         mOpenFlutter = findViewById(R.id.open_flutter);
         mOpenFlutterFragment = findViewById(R.id.open_flutter_fragment);
         mOpenCustomViewTab = findViewById(R.id.open_custom_view_tab);
+        mWarmUpCustomViewTab = findViewById(R.id.warm_up_custom_view_tab);
 
         mOpenNative.setOnClickListener(this);
         mOpenFlutter.setOnClickListener(this);
         mOpenFlutterFragment.setOnClickListener(this);
         mOpenCustomViewTab.setOnClickListener(this);
+        mWarmUpCustomViewTab.setOnClickListener(this);
     }
 
     @Override
@@ -76,6 +80,14 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             NativeRouter.openPageByUrl(this, NativeRouter.FLUTTER_FRAGMENT_PAGE_URL,params);
         } else if (v == mOpenCustomViewTab) {
             NativeRouter.openPageByUrl(this, NativeRouter.FLUTTER_CUSTOM_VIEW_URL, params);
+        } else if (v == mWarmUpCustomViewTab) {
+            String url = "tab_flutter1";
+            params.put("url", url);
+            FlutterBoostView fbv = FlutterBoostView.withCachedEngine(FlutterBoost.ENGINE_ID)
+                    .url(url)
+                    .keepCache(true)
+                    .build(this);
+            fbv.onCreate();
         }
     }
 

--- a/example/android/app/src/main/res/layout/native_page.xml
+++ b/example/android/app/src/main/res/layout/native_page.xml
@@ -44,17 +44,36 @@
         android:layout_height="wrap_content"
         android:text="@string/open_flutter" />
 
-    <TextView
-        android:background="@android:color/holo_orange_dark"
-        android:layout_margin="8.0dp"
-        android:padding="8.0dp"
-        android:textColor="@android:color/black"
-        android:id="@+id/open_custom_view_tab"
-        android:textAllCaps="false"
-        android:textSize="16sp"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/open_custom_view_tab" />
+        android:orientation="horizontal"
+        android:background="@android:color/white">
+
+        <TextView
+            android:background="@android:color/holo_orange_dark"
+            android:layout_margin="8.0dp"
+            android:padding="8.0dp"
+            android:textColor="@android:color/black"
+            android:id="@+id/open_custom_view_tab"
+            android:textAllCaps="false"
+            android:textSize="16sp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/open_custom_view_tab" />
+        <TextView
+            android:background="@android:color/holo_orange_light"
+            android:layout_margin="8.0dp"
+            android:padding="8.0dp"
+            android:textColor="@android:color/black"
+            android:id="@+id/warm_up_custom_view_tab"
+            android:textAllCaps="false"
+            android:textSize="16sp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/warm_up_custom_view_tab" />
+
+    </LinearLayout>
 
     <TextView
         android:background="@android:color/holo_orange_dark"

--- a/example/android/app/src/main/res/values/strings.xml
+++ b/example/android/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="open_flutter">open flutter page</string>
     <string name="open_flutter_fragment">open flutter fragment page</string>
     <string name="open_custom_view_tab">open custom view page</string>
+    <string name="warm_up_custom_view_tab">warm-up</string>
     <string name="native_info">This is a native activity</string>
     <string name="flutter1">Flutter1</string>
     <string name="flutter2">Flutter2</string>

--- a/example/ios/Runner/MyFlutterBoostDelegate.m
+++ b/example/ios/Runner/MyFlutterBoostDelegate.m
@@ -55,7 +55,7 @@
     if(preRender){
         [vc preRender];
         _cachedFBFlutterViewContainer = vc;
-        _cachedPageName = pageName;
+        _cachedPageName = options.pageName;
     }else if(present){
         [self.navigationController presentViewController:vc animated:animated completion:^{
             options.completion(YES);

--- a/example/ios/Runner/MyFlutterBoostDelegate.m
+++ b/example/ios/Runner/MyFlutterBoostDelegate.m
@@ -11,6 +11,11 @@
 #import "UIViewControllerDemo.h"
 #import <flutter_boost/FlutterBoost.h>
 
+@interface MyFlutterBoostDelegate()
+@property (nonatomic) FBFlutterViewContainer *cachedFBFlutterViewContainer;
+@property (nonatomic) NSString *cachedPageName;
+@end
+
 @implementation MyFlutterBoostDelegate
 
 
@@ -27,15 +32,31 @@
 }
 
 - (void)pushFlutterRoute:(FlutterBoostRouteOptions *)options {
-    FBFlutterViewContainer *vc = FBFlutterViewContainer.new;
+    BOOL preRender = [options.arguments[@"preRender"] boolValue];
+    FBFlutterViewContainer *vc = nil;
+    if (_cachedPageName != nil && [_cachedPageName isEqualToString:options.pageName]) {
+        vc = _cachedFBFlutterViewContainer;
+        _cachedFBFlutterViewContainer = nil;
+        _cachedPageName = nil;
+        if (!preRender) {
+            [[[FlutterBoost instance] engine] setViewController:vc];
+        }
+    } else {
+        vc = FBFlutterViewContainer.new;
+    }
+
     [vc setName:options.pageName uniqueId:options.uniqueId params:options.arguments opaque:options.opaque];
-    
+
     //是否伴随动画
     BOOL animated = [options.arguments[@"animated"] boolValue];
     //是否是present的方式打开,如果要push的页面是透明的，那么也要以present形式打开
     BOOL present = [options.arguments[@"present"] boolValue] || !options.opaque;
-    
-    if(present){
+
+    if(preRender){
+        [vc preRender];
+        _cachedFBFlutterViewContainer = vc;
+        _cachedPageName = pageName;
+    }else if(present){
         [self.navigationController presentViewController:vc animated:animated completion:^{
             options.completion(YES);
         }];
@@ -48,17 +69,17 @@
 - (void) popRoute:(FlutterBoostRouteOptions *)options {
     //拿到当前vc
     FBFlutterViewContainer *vc = (id)self.navigationController.presentedViewController;
-    
+
     //present的情况，走dismiss逻辑
     if([vc isKindOfClass:FBFlutterViewContainer.class] && [vc.uniqueIDString isEqual: options.uniqueId]){
-        
+
         //这里分为两种情况，由于UIModalPresentationOverFullScreen下，生命周期显示会有问题
         //所以需要手动调用的场景，从而使下面底部的vc调用viewAppear相关逻辑
         if(vc.modalPresentationStyle == UIModalPresentationOverFullScreen){
-            
+
             //这里手动beginAppearanceTransition触发页面生命周期
             [self.navigationController.topViewController beginAppearanceTransition:YES animated:NO];
-            
+
             [vc dismissViewControllerAnimated:YES completion:^{
                 [self.navigationController.topViewController endAppearanceTransition];
             }];

--- a/example/ios/Runner/UIViewControllerDemo.m
+++ b/example/ios/Runner/UIViewControllerDemo.m
@@ -24,7 +24,14 @@
 }
 
 - (IBAction)preRenderFlutterPage:(id)sender {
-    [[FlutterBoost instance] open:@"flutterPage" arguments:@{@"preRender":@(YES)}  ];
+    FlutterBoostRouteOptions* options = [[FlutterBoostRouteOptions alloc]init];
+    options.pageName = @"flutterPage";
+    options.arguments = @{@"preRender":@(YES)};
+    options.completion = ^(BOOL completion) {
+        
+    };
+    
+    [[FlutterBoost instance]open:options];
 }
 
 - (IBAction)pushFlutterPage:(id)sender {

--- a/example/ios/Runner/UIViewControllerDemo.m
+++ b/example/ios/Runner/UIViewControllerDemo.m
@@ -23,6 +23,10 @@
     // Do any additional setup after loading the view from its nib.
 }
 
+- (IBAction)preRenderFlutterPage:(id)sender {
+    [[FlutterBoost instance] open:@"flutterPage" arguments:@{@"preRender":@(YES)}  ];
+}
+
 - (IBAction)pushFlutterPage:(id)sender {
     
     FlutterBoostRouteOptions* options = [[FlutterBoostRouteOptions alloc]init];

--- a/example/ios/Runner/UIViewControllerDemo.xib
+++ b/example/ios/Runner/UIViewControllerDemo.xib
@@ -46,6 +46,17 @@
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <textInputTraits key="textInputTraits"/>
                 </textField>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="agP-ea-Mdd">
+                    <rect key="frame" x="106.5" y="276" width="162" height="30"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="162" id="4w7-aa-b3O"/>
+                        <constraint firstAttribute="height" constant="30" id="dyb-Ct-yY9"/>
+                    </constraints>
+                    <state key="normal" title="Pre-render Flutter Page"/>
+                    <connections>
+                        <action selector="preRenderFlutterPage:" destination="-1" eventType="touchUpInside" id="rMf-GU-6Tt"/>
+                    </connections>
+                </button>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
@@ -53,11 +64,13 @@
                 <constraint firstItem="bCg-og-n1K" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="9T9-4m-GgT"/>
                 <constraint firstItem="Nzh-7M-COj" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="D6k-vF-b5G"/>
                 <constraint firstItem="bCg-og-n1K" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="120" id="G4r-vQ-M9g"/>
+                <constraint firstItem="Nzh-7M-COj" firstAttribute="top" secondItem="agP-ea-Mdd" secondAttribute="bottom" constant="7.5" id="H3s-ym-sQ4"/>
                 <constraint firstItem="DT7-uk-4YM" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="a5O-rA-Z3g"/>
                 <constraint firstItem="DT7-uk-4YM" firstAttribute="top" secondItem="Nzh-7M-COj" secondAttribute="bottom" constant="7.5" id="rhd-e4-oVP"/>
                 <constraint firstItem="bCg-og-n1K" firstAttribute="width" secondItem="i5M-Pr-FkT" secondAttribute="height" multiplier="0.2" id="zgc-4g-vU3"/>
+                <constraint firstItem="agP-ea-Mdd" firstAttribute="centerX" secondItem="Nzh-7M-COj" secondAttribute="centerX" id="zp9-gR-ptd"/>
             </constraints>
-            <point key="canvasLocation" x="-759.20000000000005" y="143.47826086956522"/>
+            <point key="canvasLocation" x="-175" y="52"/>
         </view>
     </objects>
 </document>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,12 +14,6 @@ import 'package:flutter_boost_example/simple_page_widgets.dart';
 import 'package:flutter_boost_example/tab/simple_widget.dart';
 
 void main() {
-  void _setPreRenderCallback(OverlayEntry entry, bool value) {
-    print('_setPreRenderCallback entry=$entry value=$value');
-    entry.preRender = value;
-  }
-  setPreRenderCallback = _setPreRenderCallback;
-
   PageVisibilityBinding.instance
       .addGlobalObserver(AppGlobalPageVisibilityObserver());
   runApp(MyApp());

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,6 +14,12 @@ import 'package:flutter_boost_example/simple_page_widgets.dart';
 import 'package:flutter_boost_example/tab/simple_widget.dart';
 
 void main() {
+  void _setPreRenderCallback(OverlayEntry entry, bool value) {
+    print('_setPreRenderCallback entry=$entry value=$value');
+    entry.preRender = value;
+  }
+  setPreRenderCallback = _setPreRenderCallback;
+
   PageVisibilityBinding.instance
       .addGlobalObserver(AppGlobalPageVisibilityObserver());
   runApp(MyApp());

--- a/ios/Classes/container/FBFlutterContainer.h
+++ b/ios/Classes/container/FBFlutterContainer.h
@@ -29,4 +29,5 @@
 - (NSDictionary *)uniqueId;
 - (NSString *)uniqueIDString;
 - (void)setName:(NSString *)name uniqueId:(NSString *)uniqueId params:(NSDictionary *)params opaque:(BOOL) opaque;
+- (void)preRender;
 @end

--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -29,6 +29,8 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 
+#include <os/signpost.h>
+
 #define ENGINE [[FlutterBoost instance] engine]
 #define FB_PLUGIN  [FlutterBoostPlugin getPlugin: [[FlutterBoost instance] engine]]
 
@@ -159,6 +161,13 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)_setup
 {
+    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
+    if (systemVersion.floatValue > 12.0) {
+        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
+        os_signpost_id_t spid = os_signpost_id_generate(log);
+        os_signpost_event_emit(log, spid, "_setup", "name: %@", self.name);
+    }
+
     self.uniqueId = [[NSUUID UUID] UUIDString];
     [self.class instanceCounterIncrease];
 }
@@ -219,11 +228,37 @@ static NSUInteger kInstanceCounter = 0;
 }
 
 - (void)viewDidLoad {
+    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
+    if (systemVersion.floatValue > 12.0) {
+        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
+        os_signpost_id_t spid = os_signpost_id_generate(log);
+        os_signpost_event_emit(log, spid, "viewDidLoad", "name: %@", self.name);
+    }
+
     [super viewDidLoad];
     //只有在不透明情况下，才设置背景颜色，否则不设置颜色（也就是默认透明）
     if(self.opaque){
         self.view.backgroundColor = UIColor.whiteColor;
     }
+}
+
+- (void)preRender {
+    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
+    if (systemVersion.floatValue > 12.0) {
+        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
+        os_signpost_id_t spid = os_signpost_id_generate(log);
+        os_signpost_event_emit(log, spid, "preRender", "name: %@", self.name);
+    }
+
+    FBCommonParams* params = [[FBCommonParams alloc] init];
+    params.pageName = _name;
+    params.arguments = _params;
+    params.uniqueId = self.uniqueId;
+    params.preRender = [NSNumber numberWithBool:YES];
+    [FB_PLUGIN.flutterApi pushRoute: params completion:^(NSError * e) {
+
+            }];
+    [FB_PLUGIN addContainer:self];
 }
 
 #pragma mark - ScreenShots
@@ -234,6 +269,13 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)attatchFlutterEngine
 {
+    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
+    if (systemVersion.floatValue > 12.0) {
+        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
+        os_signpost_id_t spid = os_signpost_id_generate(log);
+        os_signpost_event_emit(log, spid, "attatchFlutterEngine", "name: %@", self.name);
+    }
+
     if(ENGINE.viewController != self){
         ENGINE.viewController=self;
     }
@@ -268,6 +310,13 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)viewWillAppear:(BOOL)animated
 {
+    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
+    if (systemVersion.floatValue > 12.0) {
+        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
+        os_signpost_id_t spid = os_signpost_id_generate(log);
+        os_signpost_event_emit(log, spid, "viewWillAppear", "name: %@", self.name);
+    }
+
     //For new page we should attach flutter view in view will appear
     //for better performance.
     FBCommonParams* params = [[FBCommonParams alloc] init];
@@ -290,6 +339,13 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)viewDidAppear:(BOOL)animated
 {
+    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
+    if (systemVersion.floatValue > 12.0) {
+        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
+        os_signpost_id_t spid = os_signpost_id_generate(log);
+        os_signpost_event_emit(log, spid, "viewDidAppear", "name: %@", self.name);
+    }
+
     //Ensure flutter view is attached.
     [self attatchFlutterEngine];
 
@@ -318,12 +374,26 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)viewWillDisappear:(BOOL)animated
 {
+    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
+    if (systemVersion.floatValue > 12.0) {
+        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
+        os_signpost_id_t spid = os_signpost_id_generate(log);
+        os_signpost_event_emit(log, spid, "viewWillDisappear", "name: %@", self.name);
+    }
+
     [[[UIApplication sharedApplication] keyWindow] endEditing:YES];
     [super viewWillDisappear:animated];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
+    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
+    if (systemVersion.floatValue > 12.0) {
+        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
+        os_signpost_id_t spid = os_signpost_id_generate(log);
+        os_signpost_event_emit(log, spid, "viewDidDisappear", "name: %@", self.name);
+    }
+
     [super bridge_viewDidDisappear:animated];
     FBCommonParams* params = [[FBCommonParams alloc] init];
     params.uniqueId = self.uniqueId;

--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -29,8 +29,6 @@
 #import <objc/message.h>
 #import <objc/runtime.h>
 
-#include <os/signpost.h>
-
 #define ENGINE [[FlutterBoost instance] engine]
 #define FB_PLUGIN  [FlutterBoostPlugin getPlugin: [[FlutterBoost instance] engine]]
 
@@ -161,13 +159,6 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)_setup
 {
-    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
-    if (systemVersion.floatValue > 12.0) {
-        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
-        os_signpost_id_t spid = os_signpost_id_generate(log);
-        os_signpost_event_emit(log, spid, "_setup", "name: %@", self.name);
-    }
-
     self.uniqueId = [[NSUUID UUID] UUIDString];
     [self.class instanceCounterIncrease];
 }
@@ -228,13 +219,6 @@ static NSUInteger kInstanceCounter = 0;
 }
 
 - (void)viewDidLoad {
-    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
-    if (systemVersion.floatValue > 12.0) {
-        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
-        os_signpost_id_t spid = os_signpost_id_generate(log);
-        os_signpost_event_emit(log, spid, "viewDidLoad", "name: %@", self.name);
-    }
-
     [super viewDidLoad];
     //只有在不透明情况下，才设置背景颜色，否则不设置颜色（也就是默认透明）
     if(self.opaque){
@@ -243,13 +227,6 @@ static NSUInteger kInstanceCounter = 0;
 }
 
 - (void)preRender {
-    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
-    if (systemVersion.floatValue > 12.0) {
-        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
-        os_signpost_id_t spid = os_signpost_id_generate(log);
-        os_signpost_event_emit(log, spid, "preRender", "name: %@", self.name);
-    }
-
     FBCommonParams* params = [[FBCommonParams alloc] init];
     params.pageName = _name;
     params.arguments = _params;
@@ -269,13 +246,6 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)attatchFlutterEngine
 {
-    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
-    if (systemVersion.floatValue > 12.0) {
-        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
-        os_signpost_id_t spid = os_signpost_id_generate(log);
-        os_signpost_event_emit(log, spid, "attatchFlutterEngine", "name: %@", self.name);
-    }
-
     if(ENGINE.viewController != self){
         ENGINE.viewController=self;
     }
@@ -310,13 +280,6 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)viewWillAppear:(BOOL)animated
 {
-    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
-    if (systemVersion.floatValue > 12.0) {
-        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
-        os_signpost_id_t spid = os_signpost_id_generate(log);
-        os_signpost_event_emit(log, spid, "viewWillAppear", "name: %@", self.name);
-    }
-
     //For new page we should attach flutter view in view will appear
     //for better performance.
     FBCommonParams* params = [[FBCommonParams alloc] init];
@@ -339,13 +302,6 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)viewDidAppear:(BOOL)animated
 {
-    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
-    if (systemVersion.floatValue > 12.0) {
-        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
-        os_signpost_id_t spid = os_signpost_id_generate(log);
-        os_signpost_event_emit(log, spid, "viewDidAppear", "name: %@", self.name);
-    }
-
     //Ensure flutter view is attached.
     [self attatchFlutterEngine];
 
@@ -374,26 +330,12 @@ static NSUInteger kInstanceCounter = 0;
 
 - (void)viewWillDisappear:(BOOL)animated
 {
-    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
-    if (systemVersion.floatValue > 12.0) {
-        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
-        os_signpost_id_t spid = os_signpost_id_generate(log);
-        os_signpost_event_emit(log, spid, "viewWillDisappear", "name: %@", self.name);
-    }
-
     [[[UIApplication sharedApplication] keyWindow] endEditing:YES];
     [super viewWillDisappear:animated];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
-    NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
-    if (systemVersion.floatValue > 12.0) {
-        os_log_t log = os_log_create("com.flutterboost.example", "FBFlutterViewContainer");
-        os_signpost_id_t spid = os_signpost_id_generate(log);
-        os_signpost_event_emit(log, spid, "viewDidDisappear", "name: %@", self.name);
-    }
-
     [super bridge_viewDidDisappear:animated];
     FBCommonParams* params = [[FBCommonParams alloc] init];
     params.uniqueId = self.uniqueId;

--- a/ios/Classes/messages.h
+++ b/ios/Classes/messages.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, nullable) NSString * uniqueId;
 @property(nonatomic, strong, nullable) NSDictionary * arguments;
 @property(nonatomic, strong, nullable) NSNumber * opaque;
+@property(nonatomic, strong, nullable) NSNumber * beforehand;
 @end
 
 @interface FBStackInfo : NSObject

--- a/ios/Classes/messages.h
+++ b/ios/Classes/messages.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, nullable) NSString * uniqueId;
 @property(nonatomic, strong, nullable) NSDictionary * arguments;
 @property(nonatomic, strong, nullable) NSNumber * opaque;
-@property(nonatomic, strong, nullable) NSNumber * beforehand;
+@property(nonatomic, strong, nullable) NSNumber * preRender;
 @end
 
 @interface FBStackInfo : NSObject

--- a/ios/Classes/messages.m
+++ b/ios/Classes/messages.m
@@ -50,14 +50,14 @@ static NSDictionary<NSString*, id>* wrapResult(NSDictionary *result, FlutterErro
   if ((NSNull *)result.opaque == [NSNull null]) {
     result.opaque = nil;
   }
-  result.beforehand = dict[@"beforehand"];
-  if ((NSNull *)result.beforehand == [NSNull null]) {
-    result.beforehand = nil;
+  result.preRender = dict[@"preRender"];
+  if ((NSNull *)result.preRender == [NSNull null]) {
+    result.preRender = nil;
   }
   return result;
 }
 -(NSDictionary*)toMap {
-  return [NSDictionary dictionaryWithObjectsAndKeys:(self.pageName ? self.pageName : [NSNull null]), @"pageName", (self.uniqueId ? self.uniqueId : [NSNull null]), @"uniqueId", (self.arguments ? self.arguments : [NSNull null]), @"arguments", (self.opaque ? self.opaque : [NSNull null]), @"opaque", (self.beforehand ? self.beforehand : [NSNull null]), @"beforehand", nil];
+  return [NSDictionary dictionaryWithObjectsAndKeys:(self.pageName ? self.pageName : [NSNull null]), @"pageName", (self.uniqueId ? self.uniqueId : [NSNull null]), @"uniqueId", (self.arguments ? self.arguments : [NSNull null]), @"arguments", (self.opaque ? self.opaque : [NSNull null]), @"opaque", (self.preRender ? self.preRender : [NSNull null]), @"preRender", nil];
 }
 @end
 

--- a/ios/Classes/messages.m
+++ b/ios/Classes/messages.m
@@ -50,10 +50,14 @@ static NSDictionary<NSString*, id>* wrapResult(NSDictionary *result, FlutterErro
   if ((NSNull *)result.opaque == [NSNull null]) {
     result.opaque = nil;
   }
+  result.beforehand = dict[@"beforehand"];
+  if ((NSNull *)result.beforehand == [NSNull null]) {
+    result.beforehand = nil;
+  }
   return result;
 }
 -(NSDictionary*)toMap {
-  return [NSDictionary dictionaryWithObjectsAndKeys:(self.pageName ? self.pageName : [NSNull null]), @"pageName", (self.uniqueId ? self.uniqueId : [NSNull null]), @"uniqueId", (self.arguments ? self.arguments : [NSNull null]), @"arguments", (self.opaque ? self.opaque : [NSNull null]), @"opaque", nil];
+  return [NSDictionary dictionaryWithObjectsAndKeys:(self.pageName ? self.pageName : [NSNull null]), @"pageName", (self.uniqueId ? self.uniqueId : [NSNull null]), @"uniqueId", (self.arguments ? self.arguments : [NSNull null]), @"arguments", (self.opaque ? self.opaque : [NSNull null]), @"opaque", (self.beforehand ? self.beforehand : [NSNull null]), @"beforehand", nil];
 }
 @end
 

--- a/lib/boost_flutter_router_api.dart
+++ b/lib/boost_flutter_router_api.dart
@@ -22,7 +22,7 @@ class BoostFlutterRouterApi extends FlutterRouterApi {
         uniqueId: arg.uniqueId,
         arguments:
             Map<String, dynamic>.from(arg.arguments ?? <String, dynamic>{}),
-        beforehand: arg.beforehand,
+        preRender: arg.preRender,
         withContainer: true);
   }
 

--- a/lib/boost_flutter_router_api.dart
+++ b/lib/boost_flutter_router_api.dart
@@ -22,7 +22,7 @@ class BoostFlutterRouterApi extends FlutterRouterApi {
         uniqueId: arg.uniqueId,
         arguments:
             Map<String, dynamic>.from(arg.arguments ?? <String, dynamic>{}),
-        preRender: arg.preRender,
+        preRender: arg.preRender ?? false,
         withContainer: true);
   }
 

--- a/lib/boost_flutter_router_api.dart
+++ b/lib/boost_flutter_router_api.dart
@@ -22,6 +22,7 @@ class BoostFlutterRouterApi extends FlutterRouterApi {
         uniqueId: arg.uniqueId,
         arguments:
             Map<String, dynamic>.from(arg.arguments ?? <String, dynamic>{}),
+        beforehand: arg.beforehand,
         withContainer: true);
   }
 

--- a/lib/flutter_boost.dart
+++ b/lib/flutter_boost.dart
@@ -5,4 +5,5 @@ export 'boost_lifecycle_binding.dart';
 export 'boost_navigator.dart';
 export 'flutter_boost_app.dart';
 export 'logger.dart';
+export 'overlay_entry.dart';
 export 'page_visibility.dart';

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -205,7 +205,7 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
 
   void push(String pageName,
       {String uniqueId, Map<String, dynamic> arguments,
-      bool withContainer, bool beforehand = false}) {
+      bool withContainer, bool preRender = false}) {
     _cancelActivePointers();
     final existed = _findContainerByUniqueId(uniqueId);
     if (existed != null) {
@@ -224,14 +224,13 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
           withContainer: withContainer);
       if (withContainer) {
         final container = _createContainer(pageInfo);
-        if (beforehand) {
-          // Insert just below the top container.
-          containers.insert(containers.length - 1, container);
-          BoostLifecycleBinding.instance
-              .containerDidPush(container, null);
+        if (preRender) {
+          // Insert to the bottom for just pre-render.
+          containers.insert(0, container);
+          BoostLifecycleBinding.instance.containerDidPush(container, null);
 
           // Add a new overlay entry with this container
-          refreshOnPushBeforehand(container);
+          refreshOnPushPreRender(container);
         } else {
           final previousContainer = topContainer;
           containers.add(container);
@@ -426,9 +425,9 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
   ///======== refresh method below ===============
   ///
 
-  void refreshOnPushBeforehand(BoostContainer container) {
+  void refreshOnPushPreRender(BoostContainer container) {
     refreshSpecificOverlayEntries(
-        container, BoostSpecificEntryRefreshMode.beforehand);
+        container, BoostSpecificEntryRefreshMode.preRender);
     assert(() {
       _saveStackForHotRestart();
       return true;

--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -12,7 +12,7 @@ class CommonParams {
   String uniqueId;
   Map<Object, Object> arguments;
   bool opaque;
-  bool beforehand;
+  bool preRender;
 
   Object encode() {
     final Map<Object, Object> pigeonMap = <Object, Object>{};
@@ -20,7 +20,7 @@ class CommonParams {
     pigeonMap['uniqueId'] = uniqueId;
     pigeonMap['arguments'] = arguments;
     pigeonMap['opaque'] = opaque;
-    pigeonMap['beforehand'] = beforehand;
+    pigeonMap['preRender'] = preRender;
     return pigeonMap;
   }
 
@@ -31,7 +31,7 @@ class CommonParams {
       ..uniqueId = pigeonMap['uniqueId'] as String
       ..arguments = pigeonMap['arguments'] as Map<Object, Object>
       ..opaque = pigeonMap['opaque'] as bool
-      ..beforehand = pigeonMap['beforehand'] as bool;
+      ..preRender = pigeonMap['preRender'] as bool;
   }
 }
 

--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -12,6 +12,7 @@ class CommonParams {
   String uniqueId;
   Map<Object, Object> arguments;
   bool opaque;
+  bool beforehand;
 
   Object encode() {
     final Map<Object, Object> pigeonMap = <Object, Object>{};
@@ -19,6 +20,7 @@ class CommonParams {
     pigeonMap['uniqueId'] = uniqueId;
     pigeonMap['arguments'] = arguments;
     pigeonMap['opaque'] = opaque;
+    pigeonMap['beforehand'] = beforehand;
     return pigeonMap;
   }
 
@@ -28,7 +30,8 @@ class CommonParams {
       ..pageName = pigeonMap['pageName'] as String
       ..uniqueId = pigeonMap['uniqueId'] as String
       ..arguments = pigeonMap['arguments'] as Map<Object, Object>
-      ..opaque = pigeonMap['opaque'] as bool;
+      ..opaque = pigeonMap['opaque'] as bool
+      ..beforehand = pigeonMap['beforehand'] as bool;
   }
 }
 

--- a/lib/overlay_entry.dart
+++ b/lib/overlay_entry.dart
@@ -5,6 +5,14 @@ import 'package:flutter/widgets.dart';
 
 import 'boost_container.dart';
 
+typedef FlutterBoostSetPreRenderCallback = void Function(OverlayEntry, bool);
+void _defaultSetPreRenderCallback(OverlayEntry entry, bool value) {
+  print('_defaultSetPreRenderCallback does nothing.');
+  entry.preRender = value;
+}
+///
+FlutterBoostSetPreRenderCallback setPreRenderCallback = _defaultSetPreRenderCallback;
+
 final GlobalKey<OverlayState> overlayKey = GlobalKey<OverlayState>();
 List<_ContainerOverlayEntry> _lastEntries = <_ContainerOverlayEntry>[];
 
@@ -67,10 +75,12 @@ void refreshSpecificOverlayEntries(
       _lastEntries.remove(existingEntry);
       _lastEntries.add(existingEntry);
       existingEntry.remove();
+      existingEntry.setPreRender(value: false);
       overlayState.insert(existingEntry);
       break;
     case BoostSpecificEntryRefreshMode.preRender:
       final entry = _ContainerOverlayEntry(container);
+      entry.setPreRender(value: true);
       // Insert to the bottom for just pre-render.
       final first = _lastEntries.first;
       _lastEntries.insert(0, entry);
@@ -124,6 +134,11 @@ class _ContainerOverlayEntry extends OverlayEntry {
             builder: (ctx) => BoostContainerWidget(container: container),
             opaque: true,
             maintainState: true);
+
+  void setPreRender({@required bool value}) {
+    assert(value != null);
+    setPreRenderCallback(this, value);
+  }
 
   ///This overlay's id,which is the same as the it's related container
   final String containerUniqueId;

--- a/lib/overlay_entry.dart
+++ b/lib/overlay_entry.dart
@@ -7,10 +7,16 @@ import 'boost_container.dart';
 
 typedef FlutterBoostSetPreRenderCallback = void Function(OverlayEntry, bool);
 void _defaultSetPreRenderCallback(OverlayEntry entry, bool value) {
-  print('_defaultSetPreRenderCallback does nothing.');
-  entry.preRender = value;
+  // For common flutter engine, does nothing.
 }
-///
+///For custom flutter engine, Hummer provides API [OverlayEntry.preRender] to enable 
+///pre-render an offstage OverlayEntry. If application demands this pre-rendering
+///ability, it is the responsibility of application to override [setPreRenderCallback]
+///to make use of the API, simply like:
+///void overrideSetPreRenderCallback(OverlayEntry entry, bool value) {
+///  entry.preRender = value;
+///}
+///setPreRenderCallback = overrideSetPreRenderCallback;
 FlutterBoostSetPreRenderCallback setPreRenderCallback = _defaultSetPreRenderCallback;
 
 final GlobalKey<OverlayState> overlayKey = GlobalKey<OverlayState>();
@@ -135,6 +141,7 @@ class _ContainerOverlayEntry extends OverlayEntry {
             opaque: true,
             maintainState: true);
 
+  ///Effective for Hummer only, see comments of [setPreRenderCallback].
   void setPreRender({@required bool value}) {
     assert(value != null);
     setPreRenderCallback(this, value);

--- a/lib/overlay_entry.dart
+++ b/lib/overlay_entry.dart
@@ -18,6 +18,9 @@ enum BoostSpecificEntryRefreshMode {
 
   ///move an existing entry to top
   moveToTop,
+
+  ///Add a new entry for rendering beforehand
+  beforehand,
 }
 
 ///Refresh an specific entry instead of all of entries to enhance the performace
@@ -65,6 +68,11 @@ void refreshSpecificOverlayEntries(
       _lastEntries.add(existingEntry);
       existingEntry.remove();
       overlayState.insert(existingEntry);
+      break;
+    case BoostSpecificEntryRefreshMode.beforehand:
+      final entry = _ContainerOverlayEntry(container);
+      _lastEntries.insert(_lastEntries.length - 1, entry);
+      overlayState.insert(entry, below: _lastEntries.last);
       break;
   }
 

--- a/lib/overlay_entry.dart
+++ b/lib/overlay_entry.dart
@@ -19,8 +19,8 @@ enum BoostSpecificEntryRefreshMode {
   ///move an existing entry to top
   moveToTop,
 
-  ///Add a new entry for rendering beforehand
-  beforehand,
+  ///Add a new entry for pre-rendering
+  preRender,
 }
 
 ///Refresh an specific entry instead of all of entries to enhance the performace
@@ -69,10 +69,12 @@ void refreshSpecificOverlayEntries(
       existingEntry.remove();
       overlayState.insert(existingEntry);
       break;
-    case BoostSpecificEntryRefreshMode.beforehand:
+    case BoostSpecificEntryRefreshMode.preRender:
       final entry = _ContainerOverlayEntry(container);
-      _lastEntries.insert(_lastEntries.length - 1, entry);
-      overlayState.insert(entry, below: _lastEntries.last);
+      // Insert to the bottom for just pre-render.
+      final first = _lastEntries.first;
+      _lastEntries.insert(0, entry);
+      overlayState.insert(entry, below: first);
       break;
   }
 

--- a/lib/page_visibility.dart
+++ b/lib/page_visibility.dart
@@ -96,7 +96,7 @@ class PageVisibilityBinding {
       }
     }
     Logger.log(
-        'page_visibility, #dispatchPageShowEvent, ${route.settings.name}');
+        'page_visibility, #dispatchPageCreateEvent, ${route.settings.name}');
 
     dispatchGlobalPageCreateEvent(route);
   }

--- a/pigeon/messages.dart
+++ b/pigeon/messages.dart
@@ -5,7 +5,7 @@ class CommonParams {
   String uniqueId;
   Map<String, Object> arguments;
   bool opaque;
-  bool beforehand;
+  bool preRender;
 }
 
 class StackInfo {

--- a/pigeon/messages.dart
+++ b/pigeon/messages.dart
@@ -5,6 +5,7 @@ class CommonParams {
   String uniqueId;
   Map<String, Object> arguments;
   bool opaque;
+  bool beforehand;
 }
 
 class StackInfo {


### PR DESCRIPTION
在add-to-app应用中首次打开flutter页面，页面内容的构建build&layout过程比较长，可以通过预先把flutter页面push到Overlay上进行后台构建，减少用户真正打开该页面的耗时。
对于Android端，在FlutterBoostPlugin.onContainerCreated时预先push页面；对于iOS端，FBFlutterViewContainer提供preRender接口进行预渲染。具体启动预渲染的时机由业务层根据自己的策略控制。