### PR TITLE
确保onPageShow事件能够在页面创建的时候调用到

### DIFF
--- a/example3.0/lib/pages/lifecycle_test_page.dart
+++ b/example3.0/lib/pages/lifecycle_test_page.dart
@@ -37,7 +37,7 @@ class AppLifecycleObserver with GlobalPageVisibilityObserver {
   @override
   void onPageShow(Route route) {
     super.onPageShow(route);
-    print("AppLifecycleObserver - AppLifecycleObserver");
+    print("AppLifecycleObserver - onPageShow");
   }
 }
 
@@ -90,13 +90,21 @@ class _LifecycleTestPageState extends State<LifecycleTestPage>
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      PageVisibilityBinding.instance.addObserver(this, ModalRoute.of(context));
-    });
+
+    ///请在didChangeDependencies中注册而不是initState中
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    ///注册监听器
+    PageVisibilityBinding.instance.addObserver(this, ModalRoute.of(context));
   }
 
   @override
   void dispose() {
+    ///移除监听器
     PageVisibilityBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -113,7 +121,19 @@ class _LifecycleTestPageState extends State<LifecycleTestPage>
         ),
       ),
       body: Center(
-        child: Text('simple lifecycle test page',style: TextStyle(fontSize: 24)),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('simple lifecycle test page', style: TextStyle(fontSize: 24)),
+            const SizedBox(height: 40),
+            CupertinoButton.filled(
+                child: Text('push simple page'),
+                onPressed: () {
+                  BoostNavigator.instance
+                      .push("simplePage", withContainer: true);
+                }),
+          ],
+        ),
       ),
     );
   }

--- a/lib/boost_lifecycle_binding.dart
+++ b/lib/boost_lifecycle_binding.dart
@@ -9,6 +9,12 @@ class BoostLifecycleBinding {
 
   static final BoostLifecycleBinding instance = BoostLifecycleBinding._();
 
+  ///This set contains all of the ids that has been shown
+  ///It is to solve the quesition that the page can't receive onPageShow callback event when showing
+  ///on screen first time.
+  ///Because it is not be added to [PageVisibilityBinding] before dispatching [containerDidShow] event
+  Set<String> hasShownPageIds = <String>{};
+
   void containerDidPush(
       BoostContainer container, BoostContainer previousContainer) {
     Logger.log('boost_lifecycle: BoostLifecycleBinding.containerDidPush');
@@ -21,12 +27,32 @@ class BoostLifecycleBinding {
     Logger.log('boost_lifecycle: BoostLifecycleBinding.containerDidPop');
     PageVisibilityBinding.instance
         .dispatchPageDestroyEvent(container.topPage.route);
+
+    //When container pop,remove the id from set to avoid this id still remain in the set
+    final id = container.pageInfo.uniqueId;
+    final bool removed = hasShownPageIds.remove(id);
+    assert(removed);
   }
 
   void containerDidShow(BoostContainer container) {
     Logger.log('boost_lifecycle: BoostLifecycleBinding.containerDidShow');
-    PageVisibilityBinding.instance
-        .dispatchPageShowEvent(container.topPage.route);
+
+    final id = container.pageInfo.uniqueId;
+    assert(id != null);
+    if (!hasShownPageIds.contains(id)) {
+      hasShownPageIds.add(id);
+
+      // This case indicates it is the first time that this container show
+      // So we should dispatch event in addPostFrameCallback
+      // to ensure the page will receive callback
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        PageVisibilityBinding.instance
+            .dispatchPageShowEvent(container.topPage.route);
+      });
+    } else {
+      PageVisibilityBinding.instance
+          .dispatchPageShowEvent(container.topPage.route);
+    }
   }
 
   void containerDidHide(BoostContainer container) {

--- a/lib/boost_lifecycle_binding.dart
+++ b/lib/boost_lifecycle_binding.dart
@@ -43,12 +43,11 @@ class BoostLifecycleBinding {
       hasShownPageIds.add(id);
 
       // This case indicates it is the first time that this container show
-      // So we should dispatch event in addPostFrameCallback
+      // So we should dispatch event using
+      // PageVisibilityBinding.dispatchPageShowEventOnPageShowFirstTime
       // to ensure the page will receive callback
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        PageVisibilityBinding.instance
-            .dispatchPageShowEvent(container.topPage.route);
-      });
+      PageVisibilityBinding.instance
+          .dispatchPageShowEventOnPageShowFirstTime(container.topPage.route);
     } else {
       PageVisibilityBinding.instance
           .dispatchPageShowEvent(container.topPage.route);
@@ -64,7 +63,8 @@ class BoostLifecycleBinding {
   void routeDidPush(Route<dynamic> route, Route<dynamic> previousRoute) {
     Logger.log('boost_lifecycle: BoostLifecycleBinding.routeDidPush');
     PageVisibilityBinding.instance.dispatchPageCreateEvent(route);
-    PageVisibilityBinding.instance.dispatchPageShowEvent(route);
+    PageVisibilityBinding.instance
+        .dispatchPageShowEventOnPageShowFirstTime(route);
     PageVisibilityBinding.instance.dispatchPageHideEvent(previousRoute);
   }
 

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -68,10 +68,6 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
   final Map<String, List<EventListener>> _listenersTable =
       <String, List<EventListener>>{};
 
-  ///Indicates which container is to load first time
-  ///It will be assigned when [BoostPage] is created
-  String firstTimeLoadPageId = "";
-
   @override
   void initState() {
     _containers.add(_createContainer(PageInfo(pageName: widget.initialRoute)));
@@ -142,11 +138,6 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
 
   BoostContainer _createContainer(PageInfo pageInfo) {
     pageInfo.uniqueId ??= _createUniqueId(pageInfo.pageName);
-
-    // Record the new page id to judge it is first time to load
-    // We set firstTimeLoadPageId = pageInfo.uniqueId,
-    // because the container 's first page id is container 's id
-    firstTimeLoadPageId = pageInfo.uniqueId;
     return BoostContainer(
         key: ValueKey<String>(pageInfo.uniqueId), pageInfo: pageInfo);
   }
@@ -396,19 +387,7 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
 
   void onContainerShow(CommonParams params) {
     final container = _findContainerByUniqueId(params.uniqueId);
-
-    //Indicates the first time to load page
-    if (container.pageInfo.uniqueId == firstTimeLoadPageId) {
-      //reset id to empty
-      firstTimeLoadPageId = "";
-
-      //wait frame update callback to gurantee containerDidShow event dispatch after page is created
-      WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-        BoostLifecycleBinding.instance.containerDidShow(container);
-      });
-    } else {
-      BoostLifecycleBinding.instance.containerDidShow(container);
-    }
+    BoostLifecycleBinding.instance.containerDidShow(container);
 
     // Try to complete pending native result when container closed.
     final topPage = topContainer?.topPage?.pageInfo?.uniqueId;

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -519,10 +519,7 @@ class BoostNavigatorObserver extends NavigatorObserver {
   void didPush(Route<dynamic> route, Route<dynamic> previousRoute) {
     //handle internal route
     if (previousRoute != null) {
-      //add postFrameCallback to ensure the event dispatch after the target page is created.
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        BoostLifecycleBinding.instance.routeDidPush(route, previousRoute);
-      });
+      BoostLifecycleBinding.instance.routeDidPush(route, previousRoute);
     }
     super.didPush(route, previousRoute);
   }

--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -4,7 +4,6 @@ class Logger {
       print('FlutterBoost#$msg');
       return true;
     }());
-    //print('FlutterBoost=>$msg');
   }
 
   static void error(String msg) {

--- a/lib/page_visibility.dart
+++ b/lib/page_visibility.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 import 'logger.dart';
 
@@ -120,6 +121,14 @@ class PageVisibilityBinding {
         'page_visibility, #dispatchPageShowEvent, ${route.settings.name}');
 
     dispatchGlobalPageShowEvent(route);
+  }
+
+  ///When page show first time,we should dispatch event in [FrameCallback]
+  ///to avoid the page can't receive the show event
+  void dispatchPageShowEventOnPageShowFirstTime(Route<dynamic> route) {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      dispatchPageShowEvent(route);
+    });
   }
 
   void dispatchPageHideEvent(Route<dynamic> route) {


### PR DESCRIPTION
重要解决了在页面没创建之前就发出onPageShow事件，从而造成第一次show时间无法接收的现象
目前情况：双端带容器push or 非容器push新页面，第一次show均能接收到