### PR TITLE
FIXED:HeroController.didPush assert(navigator != null) 报空异常

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,4 @@ MrThanksgiving <MrThanksgiving@163.com>
 JianweiWangs <wangjianwei.sir@gmail.com>
 JaminZhou <zhoujiamin1992@gmail.com>
 YunanChen <ync618@163.com>
+CheungSKei <180353389@qq.com>

--- a/lib/boost_container.dart
+++ b/lib/boost_container.dart
@@ -97,20 +97,22 @@ class BoostContainerState extends State<BoostContainerWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return Navigator(
-      key: widget.container._navKey,
-      pages: List<Page<dynamic>>.of(widget.container.pages),
-      onPopPage: (route, result) {
-        if (route.didPop(result)) {
-          _updatePagesList();
-          return true;
-        }
-        return false;
-      },
-      observers: <NavigatorObserver>[
-        BoostNavigatorObserver(),
-      ],
-    );
+    return HeroControllerScope(
+        controller: HeroController(),
+        child: Navigator(
+          key: widget.container._navKey,
+          pages: List<Page<dynamic>>.of(widget.container.pages),
+          onPopPage: (route, result) {
+            if (route.didPop(result)) {
+              _updatePagesList();
+              return true;
+            }
+            return false;
+          },
+          observers: <NavigatorObserver>[
+            BoostNavigatorObserver(),
+          ],
+        ));
   }
 
   @override


### PR DESCRIPTION
在多个Navigator中不允许共享HeroController对象，否则下一个退出时会置空HeroController._navigator对象时，导致上一个页面push一个新页面通过HeroController didPush时报navigator空异常
详细参考https://github.com/flutter/flutter/issues/69392