### PR TITLE
[Core Function]三端均支持pushReplacement操作用于在push页面时销毁当前页面

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -74,6 +74,7 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
                     .pageName(params.getPageName())
                     .uniqueId(params.getUniqueId())
                     .arguments((Map<String, Object>) (Object) params.getArguments())
+                    .replacement(params.getReplacement())
                     .build();
             delegate.pushFlutterRoute(options);
         } else {

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostRouteOptions.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostRouteOptions.java
@@ -7,12 +7,14 @@ public class FlutterBoostRouteOptions {
     private final Map<String, Object> arguments;
     private final int requestCode;
     private final String uniqueId;
+    private final boolean replacement;
 
     private FlutterBoostRouteOptions(FlutterBoostRouteOptions.Builder builder) {
         this.pageName = builder.pageName;
         this.arguments = builder.arguments;
         this.requestCode = builder.requestCode;
         this.uniqueId = builder.uniqueId;
+        this.replacement = builder.replacement;
     }
 
     public String pageName() {
@@ -31,11 +33,16 @@ public class FlutterBoostRouteOptions {
         return uniqueId;
     }
 
+    public boolean replacement() {
+        return replacement;
+    }
+
     public static class Builder {
         private String pageName;
         private Map<String, Object> arguments;
         private int requestCode;
         private String uniqueId;
+        private boolean replacement;
 
         public Builder() {
         }
@@ -57,6 +64,11 @@ public class FlutterBoostRouteOptions {
 
         public FlutterBoostRouteOptions.Builder uniqueId(String uniqueId) {
             this.uniqueId = uniqueId;
+            return this;
+        }
+
+        public FlutterBoostRouteOptions.Builder replacement(boolean replacement) {
+            this.replacement = replacement;
             return this;
         }
 

--- a/android/src/main/java/com/idlefish/flutterboost/Messages.java
+++ b/android/src/main/java/com/idlefish/flutterboost/Messages.java
@@ -36,6 +36,10 @@ public class Messages {
     public String getKey() { return key; }
     public void setKey(String setterArg) { this.key = setterArg; }
 
+    private Boolean replacement;
+    public Boolean getReplacement() { return replacement; }
+    public void setReplacement(Boolean setterArg) { this.replacement = setterArg; }
+
     Map<String, Object> toMap() {
       Map<String, Object> toMapResult = new HashMap<>();
       toMapResult.put("pageName", pageName);
@@ -43,6 +47,7 @@ public class Messages {
       toMapResult.put("arguments", arguments);
       toMapResult.put("opaque", opaque);
       toMapResult.put("key", key);
+      toMapResult.put("replacement", replacement);
       return toMapResult;
     }
     static CommonParams fromMap(Map<String, Object> map) {
@@ -57,6 +62,8 @@ public class Messages {
       fromMapResult.opaque = (Boolean)opaque;
       Object key = map.get("key");
       fromMapResult.key = (String)key;
+      Object replacement = map.get("replacement");
+      fromMapResult.replacement = (Boolean)replacement;
       return fromMapResult;
     }
   }

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/MyFlutterBoostDelegate.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/MyFlutterBoostDelegate.java
@@ -1,5 +1,6 @@
 package com.idlefish.flutterboost.example;
 
+import android.app.Activity;
 import android.content.Intent;
 
 import com.idlefish.flutterboost.FlutterBoost;
@@ -29,6 +30,12 @@ public class MyFlutterBoostDelegate implements FlutterBoostDelegate {
                 .url(options.pageName())
                 .urlParams(options.arguments())
                 .build(FlutterBoost.instance().currentActivity());
+
+        Activity previous = FlutterBoost.instance().currentActivity();
         FlutterBoost.instance().currentActivity().startActivity(intent);
+
+        if(options.replacement()){
+            previous.finish();
+        }
     }
 }

--- a/example3.0/ios/Runner/BoostDelegate.swift
+++ b/example3.0/ios/Runner/BoostDelegate.swift
@@ -44,6 +44,10 @@ class BoostDelegate: NSObject,FlutterBoostDelegate {
     }
     
     func pushFlutterRoute(_ options: FlutterBoostRouteOptions!) {
+        
+        FlutterBoost.instance().engine().viewController = nil
+        
+        
         let vc:FBFlutterViewContainer = FBFlutterViewContainer()
         vc.setName(options.pageName, uniqueId: options.uniqueId, params: options.arguments,opaque: options.opaque)
         
@@ -59,6 +63,12 @@ class BoostDelegate: NSObject,FlutterBoostDelegate {
             self.navigationController?.present(vc, animated: isAnimated, completion: nil)
         }else{
             self.navigationController?.pushViewController(vc, animated: isAnimated)
+            
+            if options.replacement {
+                let count = self.navigationController!.viewControllers.count
+                
+                self.navigationController?.viewControllers.remove(at: count - 2)
+            }
         }
     }
     

--- a/example3.0/lib/main.dart
+++ b/example3.0/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:example/pages/simple_replacement_page.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_boost/flutter_boost.dart';
@@ -12,6 +13,26 @@ void main() {
   PageVisibilityBinding.instance.addGlobalObserver(AppLifecycleObserver());
 
   runApp(MyApp());
+}
+
+class Simple2 extends StatefulWidget {
+  const Simple2({Key key}) : super(key: key);
+
+  @override
+  _Simple2State createState() => _Simple2State();
+}
+
+class _Simple2State extends State<Simple2> {
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+        onTap: () {
+          BoostNavigator.instance.pop();
+        },
+        child: Scaffold(
+          backgroundColor: Colors.red,
+        ));
+  }
 }
 
 class MyApp extends StatefulWidget {
@@ -44,11 +65,20 @@ class _MyAppState extends State<MyApp> {
             );
           });
     },
-
-    ///生命周期例子页面
     'lifecyclePage': (settings, uniqueId) {
       return PageRouteBuilder<dynamic>(
           settings: settings, pageBuilder: (_, __, ___) => LifecycleTestPage());
+    },
+
+
+    ///生命周期例子页面
+    'replacementPage': (settings, uniqueId) {
+      return PageRouteBuilder<dynamic>(
+          settings: settings, pageBuilder: (_, __, ___) => ReplacementPage());
+    },
+    'simple2': (settings, uniqueId) {
+      return PageRouteBuilder<dynamic>(
+          settings: settings, pageBuilder: (_, __, ___) => Simple2());
     },
 
     ///透明弹窗页面

--- a/example3.0/lib/pages/lifecycle_test_page.dart
+++ b/example3.0/lib/pages/lifecycle_test_page.dart
@@ -7,37 +7,37 @@ class AppLifecycleObserver with GlobalPageVisibilityObserver {
   @override
   void onBackground(Route route) {
     super.onBackground(route);
-    print("AppLifecycleObserver - onBackground");
+    print("AppLifecycleObserver - ${route.settings.name} - onBackground");
   }
 
   @override
   void onForeground(Route route) {
     super.onForeground(route);
-    print("AppLifecycleObserver - onForground");
+    print("AppLifecycleObserver - ${route.settings.name} - onForground");
   }
 
   @override
   void onPagePush(Route route) {
     super.onPagePush(route);
-    print("AppLifecycleObserver - onPagePush");
+    print("AppLifecycleObserver - ${route.settings.name} - onPagePush");
   }
 
   @override
   void onPagePop(Route route) {
     super.onPagePop(route);
-    print("AppLifecycleObserver - onPagePop");
+    print("AppLifecycleObserver - ${route.settings.name} - onPagePop");
   }
 
   @override
   void onPageHide(Route route) {
     super.onPageHide(route);
-    print("AppLifecycleObserver - onPageHide");
+    print("AppLifecycleObserver - ${route.settings.name} - onPageHide");
   }
 
   @override
   void onPageShow(Route route) {
     super.onPageShow(route);
-    print("AppLifecycleObserver - onPageShow");
+    print("AppLifecycleObserver - ${route.settings.name} - onPageShow");
   }
 }
 
@@ -118,7 +118,7 @@ class _LifecycleTestPageState extends State<LifecycleTestPage>
                 child: Text('push simple page'),
                 onPressed: () {
                   BoostNavigator.instance
-                      .push("simplePage", withContainer: true);
+                      .push("simple2", withContainer: true,replacement: true);
                 }),
           ],
         ),

--- a/example3.0/lib/pages/main_page.dart
+++ b/example3.0/lib/pages/main_page.dart
@@ -116,6 +116,17 @@ class _MainPageState extends State<MainPage> {
             ///如果开启新容器，需要指定opaque为false
             opaque: false);
       }),
+      Model("push replacement with container", () {
+        BoostNavigator.instance.push(
+          "replacementPage",
+          withContainer: true,
+          replacement: true,
+        );
+      }),
+      Model("push replacement without container", () {
+        BoostNavigator.instance
+            .push("replacementPage", withContainer: false, replacement: true);
+      }),
       Model("send event to native", () {
         ///传值给原生
         BoostChannel.instance

--- a/example3.0/lib/pages/simple_replacement_page.dart
+++ b/example3.0/lib/pages/simple_replacement_page.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_boost/flutter_boost.dart';
+
+class ReplacementPage extends StatefulWidget {
+  @override
+  _ReplacementPageState createState() => _ReplacementPageState();
+}
+
+class _ReplacementPageState extends State<ReplacementPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: CupertinoButton.filled(
+            child: Text('back'),
+            onPressed: () {
+              BoostNavigator.instance.pop();
+            }),
+      ),
+    );
+  }
+}

--- a/ios/Classes/FlutterBoostPlugin.m
+++ b/ios/Classes/FlutterBoostPlugin.m
@@ -80,6 +80,7 @@
     options.uniqueId = input.uniqueId;
     options.arguments = input.arguments;
     options.opaque = [input.opaque boolValue];
+    options.replacement = [input.replacement boolValue];
     
     //因为这里是flutter端开启新容器push一个页面，所以这里原生用不着，所以这里completion传一个空的即可
     options.completion = ^(BOOL completion) {

--- a/ios/Classes/Options.h
+++ b/ios/Classes/Options.h
@@ -65,4 +65,8 @@
 
 ///这个页面是否透明 注意:default value = YES
 @property(nonatomic,assign) BOOL opaque;
+
+///这个页面是否将会代替前面一个页面（也就是在push这个页面的时候，是否退出当前页面？）default value = false
+///若为true：从A->B ,push到B完成后，A页面将销毁
+@property(nonatomic, assign) BOOL replacement;
 @end

--- a/ios/Classes/messages.h
+++ b/ios/Classes/messages.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, nullable) NSDictionary * arguments;
 @property(nonatomic, strong, nullable) NSNumber * opaque;
 @property(nonatomic, copy, nullable) NSString * key;
+@property(nonatomic, strong, nullable) NSNumber * replacement;
 @end
 
 @interface FBStackInfo : NSObject

--- a/ios/Classes/messages.m
+++ b/ios/Classes/messages.m
@@ -54,10 +54,14 @@ static NSDictionary<NSString*, id>* wrapResult(NSDictionary *result, FlutterErro
   if ((NSNull *)result.key == [NSNull null]) {
     result.key = nil;
   }
+  result.replacement = dict[@"replacement"];
+  if ((NSNull *)result.replacement == [NSNull null]) {
+    result.replacement = nil;
+  }
   return result;
 }
 -(NSDictionary*)toMap {
-  return [NSDictionary dictionaryWithObjectsAndKeys:(self.pageName ? self.pageName : [NSNull null]), @"pageName", (self.uniqueId ? self.uniqueId : [NSNull null]), @"uniqueId", (self.arguments ? self.arguments : [NSNull null]), @"arguments", (self.opaque ? self.opaque : [NSNull null]), @"opaque", (self.key ? self.key : [NSNull null]), @"key", nil];
+  return [NSDictionary dictionaryWithObjectsAndKeys:(self.pageName ? self.pageName : [NSNull null]), @"pageName", (self.uniqueId ? self.uniqueId : [NSNull null]), @"uniqueId", (self.arguments ? self.arguments : [NSNull null]), @"arguments", (self.opaque ? self.opaque : [NSNull null]), @"opaque", (self.key ? self.key : [NSNull null]), @"key", (self.replacement ? self.replacement : [NSNull null]), @"replacement", nil];
 }
 @end
 

--- a/lib/boost_lifecycle_binding.dart
+++ b/lib/boost_lifecycle_binding.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/widgets.dart';
 
 import 'boost_container.dart';
@@ -31,7 +32,6 @@ class BoostLifecycleBinding {
     //When container pop,remove the id from set to avoid this id still remain in the set
     final id = container.pageInfo.uniqueId;
     final bool removed = hasShownPageIds.remove(id);
-    assert(removed);
   }
 
   void containerDidShow(BoostContainer container) {
@@ -72,6 +72,10 @@ class BoostLifecycleBinding {
     Logger.log('boost_lifecycle: BoostLifecycleBinding.routeDidPop');
     PageVisibilityBinding.instance.dispatchPageHideEvent(route);
     PageVisibilityBinding.instance.dispatchPageShowEvent(previousRoute);
+    PageVisibilityBinding.instance.dispatchPagePopEvent(route);
+  }
+
+  void routeDidRemove(Route<dynamic> route) {
     PageVisibilityBinding.instance.dispatchPagePopEvent(route);
   }
 

--- a/lib/boost_navigator.dart
+++ b/lib/boost_navigator.dart
@@ -61,7 +61,8 @@ class BoostNavigator {
   Future<T> push<T extends Object>(String name,
       {Map<String, dynamic> arguments,
       bool withContainer = false,
-      bool opaque = true}) async {
+      bool opaque = true,
+      bool replacement = false}) async {
     var pushOption =
         BoostInterceptorOption(name, arguments ?? <String, dynamic>{});
     var future = Future<dynamic>(
@@ -88,7 +89,8 @@ class BoostNavigator {
           return appState.pushWithResult(pushOption.name,
               arguments: pushOption.arguments,
               withContainer: withContainer,
-              opaque: opaque);
+              opaque: opaque,
+              replacement: replacement);
         } else {
           final params = CommonParams()
             ..pageName = pushOption.name

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -199,6 +199,7 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
         ..pageName = pageName
         ..uniqueId = uniqueId
         ..opaque = opaque
+        ..replacement = replacement
         ..arguments = arguments ?? <String, dynamic>{};
       nativeRouterApi.pushFlutterRoute(params);
     } else {

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -246,7 +246,11 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
         // In this case , we don't need to change the overlayEntries data,
         final newPage = BoostPage.create(pageInfo);
         if (replacement) {
-          topContainer.pages.removeLast();
+          final topPage = topContainer.pages.removeLast();
+
+          //This page is removed
+          //So we complete and remove its completer in set
+          _completePendingResultIfNeeded(topPage.pageInfo.uniqueId);
         }
         topContainer.pages.add(newPage);
         topContainer.refresh();

--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -13,6 +13,7 @@ class CommonParams {
   Map<Object, Object> arguments;
   bool opaque;
   String key;
+  bool replacement;
 
   Object encode() {
     final Map<Object, Object> pigeonMap = <Object, Object>{};
@@ -21,6 +22,7 @@ class CommonParams {
     pigeonMap['arguments'] = arguments;
     pigeonMap['opaque'] = opaque;
     pigeonMap['key'] = key;
+    pigeonMap['replacement'] = replacement;
     return pigeonMap;
   }
 
@@ -31,7 +33,8 @@ class CommonParams {
       ..uniqueId = pigeonMap['uniqueId'] as String
       ..arguments = pigeonMap['arguments'] as Map<Object, Object>
       ..opaque = pigeonMap['opaque'] as bool
-      ..key = pigeonMap['key'] as String;
+      ..key = pigeonMap['key'] as String
+      ..replacement = pigeonMap['replacement'] as bool;
   }
 }
 

--- a/pigeon/messages.dart
+++ b/pigeon/messages.dart
@@ -6,11 +6,9 @@ class CommonParams {
   Map<String, Object> arguments;
   bool opaque;
   String key;
+  bool replacement;
 }
 
-class EventParam{
-
-}
 class StackInfo {
   List<String> containers;
   Map<String, List<Map<String, Object>>> routes;


### PR DESCRIPTION
总体思路：
 - 容器内的flutter内部replacement：直接操纵topContainer的pages属性即可将当前的remove掉在add新的即可完成replace
 - 原生容器间的实现：将replacement属性带到原生，原生在delegate中`pushFlutterRoute`方法中利用不同的平台的方法对之前容器进行remove，比如`Android`是利用`Activity.finsh`，iOS利用`UINavigationController.viewControllers.removeAt(index)`对之前的页面进行移除，从而达到替换的效果

注意事项：在生命周期方面
 - 容器内部：要替换的BoostPage被remove的时候，`BoostNavigatorObserver`会走`didRemove`，所以这里需要单独处理被remove的这个路由即可
 - 容器间：当原生容器调用页面销毁方法的时候，容器生命周期的销毁逻辑会自动将对应的overlayEntry从数据中删除。所以这里不需要管在pushReplacement场景下overlayEntry的数据刷新问题
