### PR TITLE
BoostNavigator添加pushReplacement方法，同时修复pop和findContainerById的逻辑

### DIFF
--- a/example3.0/ios/Runner/BoostDelegate.swift
+++ b/example3.0/ios/Runner/BoostDelegate.swift
@@ -40,10 +40,6 @@ class BoostDelegate: NSObject,FlutterBoostDelegate {
     }
     
     func pushFlutterRoute(_ options: FlutterBoostRouteOptions!) {
-        
-        let engine = FlutterBoost.instance().engine()
-        engine?.viewController = nil
-        
         let vc:FBFlutterViewContainer = FBFlutterViewContainer()
         vc.setName(options.pageName, uniqueId: options.uniqueId, params: options.arguments,opaque: options.opaque)
         
@@ -52,7 +48,7 @@ class BoostDelegate: NSObject,FlutterBoostDelegate {
         let isAnimated = (options.arguments?["isAnimated"] as? Bool) ?? true
         
         //对这个页面设置结果
-        resultTable[options.pageName] = options.onPageFinished;
+        resultTable[vc.uniqueIDString()] = options.onPageFinished;
         
         //如果是present模式 ，或者要不透明模式，那么就需要以present模式打开页面
         if(isPresent || !options.opaque){
@@ -108,9 +104,9 @@ class BoostDelegate: NSObject,FlutterBoostDelegate {
         }
         
         //这里在pop的时候将参数带出,并且从结果表中移除
-        if let onPageFinshed = resultTable[options.pageName] {
+        if let onPageFinshed = resultTable[options.uniqueId] {
             onPageFinshed(options.arguments)
-            resultTable.removeValue(forKey: options.pageName)
+            resultTable.removeValue(forKey: options.uniqueId)
         }
         
     }

--- a/example3.0/ios/Runner/BoostDelegate.swift
+++ b/example3.0/ios/Runner/BoostDelegate.swift
@@ -8,10 +8,6 @@
 import UIKit
 import flutter_boost
 
-
-import UIKit
-import flutter_boost
-
 class BoostDelegate: NSObject,FlutterBoostDelegate {
     
     ///您用来push的导航栏
@@ -44,6 +40,10 @@ class BoostDelegate: NSObject,FlutterBoostDelegate {
     }
     
     func pushFlutterRoute(_ options: FlutterBoostRouteOptions!) {
+        
+        let engine = FlutterBoost.instance().engine()
+        engine?.viewController = nil
+        
         let vc:FBFlutterViewContainer = FBFlutterViewContainer()
         vc.setName(options.pageName, uniqueId: options.uniqueId, params: options.arguments,opaque: options.opaque)
         
@@ -82,10 +82,30 @@ class BoostDelegate: NSObject,FlutterBoostDelegate {
             }
             
         }else{
-            self.navigationController?.popViewController(animated: true)
+            //pop场景
+            
+            //找到和要移除的id对应的vc
+            guard let viewControllers = self.navigationController?.viewControllers else{
+                return
+            }
+            
+            var containerToRemove:FBFlutterViewContainer?
+            for item in viewControllers.reversed() {
+                if let container = item as? FBFlutterViewContainer,container.uniqueIDString() == options.uniqueId {
+                    containerToRemove = container
+                    break
+                }
+            }
+            if(containerToRemove == nil){
+                fatalError("uniqueId is wrong!!!")
+            }
+            
+            if self.navigationController?.topViewController == containerToRemove {
+                self.navigationController?.popViewController(animated: true)
+            }else{
+                containerToRemove?.removeFromParent()
+            }
         }
-        
-        //否则直接执行pop逻辑
         
         //这里在pop的时候将参数带出,并且从结果表中移除
         if let onPageFinshed = resultTable[options.pageName] {

--- a/example3.0/lib/main.dart
+++ b/example3.0/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter_boost/flutter_boost.dart';
 import 'pages/dialog_page.dart';
 import 'pages/lifecycle_test_page.dart';
 import 'pages/main_page.dart';
+import 'pages/replacement_page.dart';
 import 'pages/simple_page.dart';
 
 void main() {
@@ -49,6 +50,10 @@ class _MyAppState extends State<MyApp> {
     'lifecyclePage': (settings, uniqueId) {
       return PageRouteBuilder<dynamic>(
           settings: settings, pageBuilder: (_, __, ___) => LifecycleTestPage());
+    },
+    'replacementPage': (settings, uniqueId) {
+      return PageRouteBuilder<dynamic>(
+          settings: settings, pageBuilder: (_, __, ___) => ReplacementPage());
     },
 
     ///透明弹窗页面

--- a/example3.0/lib/pages/lifecycle_test_page.dart
+++ b/example3.0/lib/pages/lifecycle_test_page.dart
@@ -7,37 +7,37 @@ class AppLifecycleObserver with GlobalPageVisibilityObserver {
   @override
   void onBackground(Route route) {
     super.onBackground(route);
-    print("AppLifecycleObserver - onBackground");
+    print("AppLifecycleObserver - ${route.settings.name} - onBackground");
   }
 
   @override
   void onForeground(Route route) {
     super.onForeground(route);
-    print("AppLifecycleObserver - onForground");
+    print("AppLifecycleObserver ${route.settings.name} - onForground");
   }
 
   @override
   void onPagePush(Route route) {
     super.onPagePush(route);
-    print("AppLifecycleObserver - onPagePush");
+    print("AppLifecycleObserver - ${route.settings.name}- onPagePush");
   }
 
   @override
   void onPagePop(Route route) {
     super.onPagePop(route);
-    print("AppLifecycleObserver - onPagePop");
+    print("AppLifecycleObserver - ${route.settings.name}- onPagePop");
   }
 
   @override
   void onPageHide(Route route) {
     super.onPageHide(route);
-    print("AppLifecycleObserver - onPageHide");
+    print("AppLifecycleObserver - ${route.settings.name}- onPageHide");
   }
 
   @override
   void onPageShow(Route route) {
     super.onPageShow(route);
-    print("AppLifecycleObserver - onPageShow");
+    print("AppLifecycleObserver - ${route.settings.name}- onPageShow");
   }
 }
 

--- a/example3.0/lib/pages/main_page.dart
+++ b/example3.0/lib/pages/main_page.dart
@@ -101,12 +101,16 @@ class _MainPageState extends State<MainPage> {
           withContainer: true,
         );
       }),
-      Model("open dialog without container", () {
-        BoostNavigator.instance.push(
-          "dialogPage",
+      Model("push replacement with Container", () {
+        BoostNavigator.instance.pushReplacement(
+          "replacementPage",
+          withContainer: true,
+        );
+      }),
+      Model("push replacement without container", () {
+        BoostNavigator.instance.pushReplacement(
+          "replacementPage",
           withContainer: false,
-
-          ///如果不需要开启新容器的情况下可以不用管opaque参数
         );
       }),
       Model("open dialog with container", () {

--- a/example3.0/lib/pages/replacement_page.dart
+++ b/example3.0/lib/pages/replacement_page.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_boost/flutter_boost.dart';
+
+class ReplacementPage extends StatefulWidget {
+  const ReplacementPage({Key key}) : super(key: key);
+
+  @override
+  _ReplacementPageState createState() => _ReplacementPageState();
+}
+
+class _ReplacementPageState extends State<ReplacementPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: CupertinoButton.filled(
+            child: Text('back'),
+            onPressed: () {
+              BoostNavigator.instance.pop();
+            }),
+      ),
+    );
+  }
+}

--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -181,8 +181,8 @@ static NSUInteger kInstanceCounter = 0;
 - (void)didMoveToParentViewController:(UIViewController *)parent {
     if (!parent) {
         //当VC被移出parent时，就通知flutter层销毁page
-        [self notifyWillDealloc];
         [self detachFlutterEngineIfNeeded];
+        [self notifyWillDealloc];
     }
     [super didMoveToParentViewController:parent];
 }
@@ -194,8 +194,8 @@ static NSUInteger kInstanceCounter = 0;
             completion();
         }
         //当VC被dismiss时，就通知flutter层销毁page
-        [self notifyWillDealloc];
         [self detachFlutterEngineIfNeeded];
+        [self notifyWillDealloc];
     }];
 }
 

--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -69,12 +69,12 @@
 
 - (instancetype)init
 {
+    ENGINE.viewController = nil;
     if(self = [super initWithEngine:ENGINE
                             nibName:_flbNibName
                              bundle:_flbNibBundle]){
         //NOTES:在present页面时，默认是全屏，如此可以触发底层VC的页面事件。否则不会触发而导致异常
         self.modalPresentationStyle = UIModalPresentationFullScreen;
-        
         [self _setup];
     }
     return self;
@@ -83,6 +83,7 @@
 - (instancetype)initWithProject:(FlutterDartProject*)projectOrNil
                         nibName:(NSString*)nibNameOrNil
                          bundle:(NSBundle*)nibBundleOrNil  {
+    ENGINE.viewController = nil;
     if (self = [super initWithProject:projectOrNil nibName:nibNameOrNil bundle:nibBundleOrNil]) {
         [self _setup];
     }
@@ -103,6 +104,7 @@
 - (instancetype)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
     _flbNibName = nibNameOrNil;
     _flbNibBundle = nibBundleOrNil;
+    ENGINE.viewController = nil;
     return [self init];
 }
 

--- a/lib/boost_lifecycle_binding.dart
+++ b/lib/boost_lifecycle_binding.dart
@@ -30,8 +30,7 @@ class BoostLifecycleBinding {
 
     //When container pop,remove the id from set to avoid this id still remain in the set
     final id = container.pageInfo.uniqueId;
-    final bool removed = hasShownPageIds.remove(id);
-    assert(removed);
+    hasShownPageIds.remove(id);
   }
 
   void containerDidShow(BoostContainer container) {
@@ -72,6 +71,11 @@ class BoostLifecycleBinding {
     Logger.log('boost_lifecycle: BoostLifecycleBinding.routeDidPop');
     PageVisibilityBinding.instance.dispatchPageHideEvent(route);
     PageVisibilityBinding.instance.dispatchPageShowEvent(previousRoute);
+    PageVisibilityBinding.instance.dispatchPagePopEvent(route);
+  }
+
+  void routeDidRemove(Route<dynamic> route){
+    Logger.log('boost_lifecycle: BoostLifecycleBinding.routeDidRemove');
     PageVisibilityBinding.instance.dispatchPagePopEvent(route);
   }
 

--- a/lib/boost_navigator.dart
+++ b/lib/boost_navigator.dart
@@ -103,6 +103,22 @@ class BoostNavigator {
     });
   }
 
+  ///1.Push a new page onto pageStack
+  ///2.remove(pop) previous page
+  Future<T> pushReplacement<T extends Object>(String name,
+      {Map<String, dynamic> arguments, bool withContainer = false}) async {
+    final id = getTopPageInfo().uniqueId;
+
+    final result =
+        push(name, arguments: arguments, withContainer: withContainer);
+
+
+    Future.delayed(const Duration(milliseconds: 100), () {
+      remove(id);
+    });
+    return result;
+  }
+
   /// Pop the top-most page off the hybrid stack.
   Future<bool> pop<T extends Object>([T result]) async =>
       await appState.popWithResult(result);

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -265,7 +265,7 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     if (uniqueId != null) {
       container = _findContainerByUniqueId(uniqueId);
       if (container == null) {
-        Logger.error('uniqueId=$uniqueId not find');
+        Logger.error('uniqueId=$uniqueId not found');
         return false;
       }
       if (container != topContainer) {
@@ -280,14 +280,28 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     assert(currentPage != null);
     _completePendingResultIfNeeded(currentPage);
 
-    final handled = await container?.navigator?.maybePop();
-    if (handled != null && !handled) {
-      assert(container.pageInfo.withContainer);
-      final params = CommonParams()
-        ..pageName = container.pageInfo.pageName
-        ..uniqueId = container.pageInfo.uniqueId
-        ..arguments = arguments ?? <String, dynamic>{};
-      await nativeRouterApi.popRoute(params);
+    //  1.If uniqueId == null,indicate we simply call BoostNavigaotor.pop(),
+    //so we call navigator?.maybePop();
+    //  2.If uniqueId is topPage's uniqueId,so we navigator?.maybePop();
+    //  3.If uniqueId is not topPage's uniqueId,so we will remove an existing page in container
+    if (uniqueId == null ||
+        uniqueId == container.pages.last.pageInfo.uniqueId) {
+      final handled = await container?.navigator?.maybePop();
+      if (handled != null && !handled) {
+        assert(container.pageInfo.withContainer);
+        final params = CommonParams()
+          ..pageName = container.pageInfo.pageName
+          ..uniqueId = container.pageInfo.uniqueId
+          ..arguments = arguments ?? <String, dynamic>{};
+        await nativeRouterApi.popRoute(params);
+      }
+    } else {
+      _completePendingResultIfNeeded(uniqueId);
+      container.pages.removeWhere((element) {
+        return element.pageInfo.uniqueId == uniqueId;
+      });
+
+      container.refresh();
     }
 
     Logger.log(
@@ -296,14 +310,13 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
   }
 
   Future<void> _removeContainer(BoostContainer container) async {
-    containers.remove(container);
     if (container.pageInfo.withContainer) {
       Logger.log('_removeContainer ,  uniqueId=${container.pageInfo.uniqueId}');
       final params = CommonParams()
         ..pageName = container.pageInfo.pageName
         ..uniqueId = container.pageInfo.uniqueId
         ..arguments = container.pageInfo.arguments;
-       return await _nativeRouterApi.popRoute(params);
+      return await _nativeRouterApi.popRoute(params);
     }
   }
 
@@ -316,10 +329,25 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
   }
 
   BoostContainer _findContainerByUniqueId(String uniqueId) {
+    //Because first page can be removed from container.
+    //So we find id in container's PageInfo
+    //If we can't find a container matching this id,
+    //we will traverse all pages in all containers
+    //to find the page matching this id,and return its container
+    //
+    //If we can't find any container or page matching this id,we return null
+
+    BoostContainer result = containers.singleWhere(
+        (element) => element.pageInfo.uniqueId == uniqueId,
+        orElse: () => null);
+
+    if (result != null) {
+      return result;
+    }
+
     return containers.singleWhere(
-            (element) =>
-            element.pages.any((element) =>
-            element.pageInfo.uniqueId == uniqueId),
+        (element) => element.pages
+            .any((element) => element.pageInfo.uniqueId == uniqueId),
         orElse: () => null);
   }
 
@@ -532,5 +560,13 @@ class BoostNavigatorObserver extends NavigatorObserver {
       BoostLifecycleBinding.instance.routeDidPop(route, previousRoute);
     }
     super.didPop(route, previousRoute);
+  }
+
+  @override
+  void didRemove(Route route, Route previousRoute) {
+    super.didRemove(route, previousRoute);
+    if (route != null) {
+      BoostLifecycleBinding.instance.routeDidRemove(route);
+    }
   }
 }


### PR DESCRIPTION
#### pushReplacement本质是两个API的调用组合，先push后remove

#### 逻辑修改部分注意两个点
 - 之前的pop逻辑：在id不为空，且id属于在顶部container的非顶部页面的时候，移除会失效，具体看pop修改代码即可-   
 - 2.findContainerById进行了修改，原因在于，在remove了container的第一个页面之后，如果单单靠page的pageInfo的id来寻找container就有了问题，所以，现在的思路是先从container的pageInfo找id，如果找到了，返回，如果找不到，再到page里面去找