### PR TITLE
[Android] 明确禁止业务在Dart代码被执行前发送channel消息，避免潜在的消息丢失问题

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
@@ -231,22 +231,17 @@ public class FlutterBoost {
             this.isBackForegroundEventOverridden = isBackForegroundEventOverridden;
         }
 
-        private void dispatchForegroundEvent() {
+        private void dispatchBackForegroundEvent(boolean background) {
             if (isBackForegroundEventOverridden) {
                 return;
             }
 
-            FlutterBoost.instance().setAppIsInBackground(false);
-            FlutterBoost.instance().getPlugin().onForeground();
-        }
-
-        private void dispatchBackgroundEvent() {
-            if (isBackForegroundEventOverridden) {
-                return;
+            if (background) {
+                FlutterBoost.instance().getPlugin().onBackground();
+            } else {
+                FlutterBoost.instance().getPlugin().onForeground();\
             }
-
-            FlutterBoost.instance().setAppIsInBackground(true);
-            FlutterBoost.instance().getPlugin().onBackground();
+            FlutterBoost.instance().setAppIsInBackground(background);
         }
 
         @Override
@@ -258,7 +253,7 @@ public class FlutterBoost {
         public void onActivityStarted(Activity activity) {
             if (++activityReferences == 1 && !isActivityChangingConfigurations) {
                 // App enters foreground
-                dispatchForegroundEvent();
+                dispatchBackForegroundEvent(false);
             }
         }
 
@@ -276,7 +271,7 @@ public class FlutterBoost {
             isActivityChangingConfigurations = activity.isChangingConfigurations();
             if (--activityReferences == 0 && !isActivityChangingConfigurations) {
                 // App enters background
-                dispatchBackgroundEvent();
+                dispatchBackForegroundEvent(true);
             }
 
         }

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -3,6 +3,10 @@ package com.idlefish.flutterboost;
 import android.util.Log;
 import android.util.SparseArray;
 
+import com.idlefish.flutterboost.Messages.CommonParams;
+import com.idlefish.flutterboost.Messages.FlutterRouterApi;
+import com.idlefish.flutterboost.Messages.NativeRouterApi;
+import com.idlefish.flutterboost.Messages.StackInfo;
 import com.idlefish.flutterboost.containers.FlutterContainerManager;
 import com.idlefish.flutterboost.containers.FlutterViewContainer;
 
@@ -11,21 +15,23 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 
-public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterApi, ActivityAware {
+public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, ActivityAware {
     private static final String TAG = FlutterBoostPlugin.class.getSimpleName();
-    private Messages.FlutterRouterApi channel;
+    private FlutterEngine engine;
+    private FlutterRouterApi channel;
     private FlutterBoostDelegate delegate;
-    private Messages.StackInfo dartStack;
+    private StackInfo dartStack;
     private SparseArray<String> pageNames;
     private int requestCode = 1000;
 
     private HashMap<String, LinkedList<EventListener>> listenersTable = new HashMap<>();
 
-    public Messages.FlutterRouterApi getChannel() {
+    public FlutterRouterApi getChannel() {
         return channel;
     }
 
@@ -39,18 +45,20 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
 
     @Override
     public void onAttachedToEngine(FlutterPluginBinding binding) {
-        Messages.NativeRouterApi.setup(binding.getBinaryMessenger(), this);
-        channel = new Messages.FlutterRouterApi(binding.getBinaryMessenger());
+        NativeRouterApi.setup(binding.getBinaryMessenger(), this);
+        engine = binding.getFlutterEngine();
+        channel = new FlutterRouterApi(binding.getBinaryMessenger());
         pageNames = new SparseArray<String>();
     }
 
     @Override
     public void onDetachedFromEngine(FlutterPluginBinding binding) {
+        engine = null;
         channel = null;
     }
 
     @Override
-    public void pushNativeRoute(Messages.CommonParams params) {
+    public void pushNativeRoute(CommonParams params) {
         if (delegate != null) {
             requestCode++;
             if (pageNames != null) {
@@ -68,7 +76,7 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
     }
 
     @Override
-    public void pushFlutterRoute(Messages.CommonParams params) {
+    public void pushFlutterRoute(CommonParams params) {
         if (delegate != null) {
             FlutterBoostRouteOptions options = new FlutterBoostRouteOptions.Builder()
                     .pageName(params.getPageName())
@@ -82,7 +90,7 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
     }
 
     @Override
-    public void popRoute(Messages.CommonParams params) {
+    public void popRoute(CommonParams params) {
         String uniqueId = params.getUniqueId();
         if (uniqueId != null) {
             FlutterViewContainer container = FlutterContainerManager.instance().findContainerById(uniqueId);
@@ -95,22 +103,22 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
     }
 
     @Override
-    public Messages.StackInfo getStackFromHost() {
+    public StackInfo getStackFromHost() {
         if (dartStack == null) {
-            return Messages.StackInfo.fromMap(new HashMap());
+            return StackInfo.fromMap(new HashMap());
         }
         Log.v(TAG, "#getStackFromHost: " + dartStack);
         return dartStack;
     }
 
     @Override
-    public void saveStackToHost(Messages.StackInfo arg) {
+    public void saveStackToHost(StackInfo arg) {
         dartStack = arg;
         Log.v(TAG, "#saveStackToHost: " + dartStack);
     }
 
     @Override
-    public void sendEventToNative(Messages.CommonParams arg) {
+    public void sendEventToNative(CommonParams arg) {
         //deal with the event from flutter side
         String key = arg.getKey();
         Map<Object, Object> arguments = arg.getArguments();
@@ -125,8 +133,7 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
             return;
         }
 
-        for (EventListener listener :
-                listeners) {
+        for (EventListener listener : listeners) {
             listener.onEvent(key, arguments);
         }
     }
@@ -145,14 +152,19 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
         return () -> finalListeners.remove(listener);
     }
 
-    public interface Reply<T> {
-        void reply(T reply);
+    private void checkEngineState() {
+        if (engine == null || engine.getDartExecutor().isExecutingDart()) {
+            throw new RuntimeException("The engine is not ready for use. " +
+                    "The message may be drop silently by the engine. " +
+                    "You should check 'DartExecutor.isExecutingDart()' first!");
+        }
     }
 
     public void pushRoute(String uniqueId, String pageName, Map<String, Object> arguments,
-                          final Reply<Void> callback) {
+                          final FlutterRouterApi.Reply<Void> callback) {
         if (channel != null) {
-            Messages.CommonParams params = new Messages.CommonParams();
+            checkEngineState();
+            CommonParams params = new CommonParams();
             params.setUniqueId(uniqueId);
             params.setPageName(pageName);
             params.setArguments((Map<Object, Object>) (Object) arguments);
@@ -166,9 +178,10 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
         }
     }
 
-    public void popRoute(String uniqueId, final Reply<Void> callback) {
+    public void popRoute(String uniqueId, final FlutterRouterApi.Reply<Void> callback) {
         if (channel != null) {
-            Messages.CommonParams params = new Messages.CommonParams();
+            checkEngineState();
+            CommonParams params = new CommonParams();
             params.setUniqueId(uniqueId);
             channel.popRoute(params, reply -> {
                 if (callback != null) {
@@ -180,9 +193,10 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
         }
     }
 
-    public void removeRoute(String uniqueId, final Reply<Void> callback) {
+    public void removeRoute(String uniqueId, final FlutterRouterApi.Reply<Void> callback) {
         if (channel != null) {
-            Messages.CommonParams params = new Messages.CommonParams();
+            checkEngineState();
+            CommonParams params = new CommonParams();
             params.setUniqueId(uniqueId);
             channel.removeRoute(params, reply -> {
                 if (callback != null) {
@@ -196,7 +210,8 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
 
     public void onForeground() {
         if (channel != null) {
-            Messages.CommonParams params = new Messages.CommonParams();
+            checkEngineState();
+            CommonParams params = new CommonParams();
             channel.onForeground(params, reply -> {
             });
         } else {
@@ -207,7 +222,8 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
 
     public void onBackground() {
         if (channel != null) {
-            Messages.CommonParams params = new Messages.CommonParams();
+            checkEngineState();
+            CommonParams params = new CommonParams();
             channel.onBackground(params, reply -> {
             });
         } else {
@@ -218,7 +234,8 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
 
     public void onContainerShow(String uniqueId) {
         if (channel != null) {
-            Messages.CommonParams params = new Messages.CommonParams();
+            checkEngineState();
+            CommonParams params = new CommonParams();
             params.setUniqueId(uniqueId);
             channel.onContainerShow(params, reply -> {
             });
@@ -230,7 +247,8 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
 
     public void onContainerHide(String uniqueId) {
         if (channel != null) {
-            Messages.CommonParams params = new Messages.CommonParams();
+            checkEngineState();
+            CommonParams params = new CommonParams();
             params.setUniqueId(uniqueId);
             channel.onContainerHide(params, reply -> {
             });
@@ -247,7 +265,7 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
     public void onContainerAppeared(FlutterViewContainer container) {
         String uniqueId = container.getUniqueId();
         FlutterContainerManager.instance().reorderContainer(uniqueId, container);
-        pushRoute(uniqueId, container.getUrl(), container.getUrlParams(), null);
+        pushRoute(uniqueId, container.getUrl(), container.getUrlParams(), reply -> {});
 
         onContainerShow(uniqueId);
         Log.v(TAG, "#onContainerAppeared: " + uniqueId + ", " + FlutterContainerManager.instance().getContainers());
@@ -261,7 +279,7 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
 
     public void onContainerDestroyed(FlutterViewContainer container) {
         String uniqueId = container.getUniqueId();
-        removeRoute(uniqueId, null);
+        removeRoute(uniqueId, reply -> {});
         FlutterContainerManager.instance().removeContainer(uniqueId);
         Log.v(TAG, "#onContainerDestroyed: " + uniqueId + ", " + FlutterContainerManager.instance().getContainers());
     }
@@ -270,7 +288,8 @@ public class FlutterBoostPlugin implements FlutterPlugin, Messages.NativeRouterA
     public void onAttachedToActivity(ActivityPluginBinding activityPluginBinding) {
         activityPluginBinding.addActivityResultListener((requestCode, resultCode, intent) -> {
             if (channel != null) {
-                Messages.CommonParams params = new Messages.CommonParams();
+                checkEngineState();
+                CommonParams params = new CommonParams();
                 String pageName = pageNames.get(requestCode);
                 pageNames.remove(requestCode);
                 if (null != pageName) {

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -153,7 +153,7 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
     }
 
     private void checkEngineState() {
-        if (engine == null || engine.getDartExecutor().isExecutingDart()) {
+        if (engine == null || !engine.getDartExecutor().isExecutingDart()) {
             throw new RuntimeException("The engine is not ready for use. " +
                     "The message may be drop silently by the engine. " +
                     "You should check 'DartExecutor.isExecutingDart()' first!");


### PR DESCRIPTION
业务可以在引擎setup的Callback后，给dart发送消息，或者发送消息前检查DartExecutor.isExecutingDart，暂时没有必要提供，dart侧ready的回调通知。