### PR TITLE
让容器数量决定Flutter的resume和pause状态，而不是前后台

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import com.idlefish.flutterboost.containers.FlutterContainerManager;
 import com.idlefish.flutterboost.containers.FlutterViewContainer;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import io.flutter.embedding.engine.FlutterEngine;
@@ -16,11 +17,16 @@ import io.flutter.view.FlutterMain;
 
 public class FlutterBoost {
     public static final String ENGINE_ID = "flutter_boost_default_engine";
+    public static final String APP_LIFECYCLE_CHANGED_KEY = "app_lifecycle_changed_key";
+    public static final String LIFECYCLE_STATE = "lifecycleState";
+    public static final int FLUTTER_APP_STATE_RESUMED = 0;
+    public static final int FLUTTER_APP_STATE_PAUSED = 2;
 
     private Activity topActivity = null;
     private FlutterBoostPlugin plugin;
     private boolean isBackForegroundEventOverridden = false;
     private boolean isAppInBackground = false;
+
 
     private FlutterBoost() {
     }
@@ -220,6 +226,13 @@ public class FlutterBoost {
 
     /*package*/ void setAppIsInBackground(boolean inBackground) {
         isAppInBackground = inBackground;
+    }
+
+    public void changeFlutterAppLifecycle(int state) {
+        assert (state == FLUTTER_APP_STATE_PAUSED || state == FLUTTER_APP_STATE_RESUMED);
+        Map arguments = new HashMap();
+        arguments.put(LIFECYCLE_STATE, state);
+        sendEventToFlutter(APP_LIFECYCLE_CHANGED_KEY, arguments);
     }
 
     private class BoostActivityLifecycle implements Application.ActivityLifecycleCallbacks {

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -260,28 +260,35 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
 
     public void onContainerCreated(FlutterViewContainer container) {
         Log.v(TAG, "#onContainerCreated: " + container.getUniqueId());
+        FlutterContainerManager.instance().addContainer(container.getUniqueId(), container);
+        if (FlutterContainerManager.instance().getContainerSize() == 1) {
+           FlutterBoost.instance().changeFlutterAppLifecycle(FlutterBoost.FLUTTER_APP_STATE_RESUMED);
+        }
     }
 
     public void onContainerAppeared(FlutterViewContainer container) {
         String uniqueId = container.getUniqueId();
-        FlutterContainerManager.instance().reorderContainer(uniqueId, container);
+        FlutterContainerManager.instance().activateContainer(uniqueId, container);
         pushRoute(uniqueId, container.getUrl(), container.getUrlParams(), reply -> {});
 
         onContainerShow(uniqueId);
-        Log.v(TAG, "#onContainerAppeared: " + uniqueId + ", " + FlutterContainerManager.instance().getContainers());
+//        Log.v(TAG, "#onContainerAppeared: " + uniqueId + ", " + FlutterContainerManager.instance().getContainers());
     }
 
     public void onContainerDisappeared(FlutterViewContainer container) {
         String uniqueId = container.getUniqueId();
         onContainerHide(uniqueId);
-        Log.v(TAG, "#onContainerDisappeared: " + uniqueId + ", " + FlutterContainerManager.instance().getContainers());
+//        Log.v(TAG, "#onContainerDisappeared: " + uniqueId + ", " + FlutterContainerManager.instance().getContainers());
     }
 
     public void onContainerDestroyed(FlutterViewContainer container) {
         String uniqueId = container.getUniqueId();
         removeRoute(uniqueId, reply -> {});
         FlutterContainerManager.instance().removeContainer(uniqueId);
-        Log.v(TAG, "#onContainerDestroyed: " + uniqueId + ", " + FlutterContainerManager.instance().getContainers());
+        if (FlutterContainerManager.instance().getContainerSize() == 0) {
+            FlutterBoost.instance().changeFlutterAppLifecycle(FlutterBoost.FLUTTER_APP_STATE_PAUSED);
+        }
+//        Log.v(TAG, "#onContainerDestroyed: " + uniqueId + ", " + FlutterContainerManager.instance().getContainers());
     }
 
     @Override

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterContainerManager.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterContainerManager.java
@@ -1,12 +1,16 @@
 package com.idlefish.flutterboost.containers;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 public class FlutterContainerManager {
 
-    private FlutterContainerManager() {}
+    private FlutterContainerManager() {
+    }
+
     private static class LazyHolder {
         static final FlutterContainerManager INSTANCE = new FlutterContainerManager();
     }
@@ -15,7 +19,30 @@ public class FlutterContainerManager {
         return FlutterContainerManager.LazyHolder.INSTANCE;
     }
 
-    private final Map<String, FlutterViewContainer> allContainers = new LinkedHashMap<>();
+    private final Map<String, FlutterViewContainer> allContainers = new HashMap<>();
+    private final LinkedList<FlutterViewContainer> activeContainers = new LinkedList<>();
+
+    public void addContainer(String uniqueId, FlutterViewContainer container) {
+        allContainers.put(uniqueId, container);
+
+    }
+
+    public void activateContainer(String uniqueId, FlutterViewContainer container) {
+        if (uniqueId == null || container == null) return;
+        assert (allContainers.containsKey(uniqueId));
+
+        if (activeContainers.contains(container)) {
+            activeContainers.remove(container);
+        }
+        activeContainers.add(container);
+    }
+
+    public void removeContainer(String uniqueId) {
+        if (uniqueId == null) return;
+        FlutterViewContainer container = allContainers.remove(uniqueId);
+        activeContainers.remove(container);
+    }
+
 
     public FlutterViewContainer findContainerById(String uniqueId) {
         if (allContainers.containsKey(uniqueId)) {
@@ -25,9 +52,8 @@ public class FlutterContainerManager {
     }
 
     public FlutterViewContainer getTopContainer() {
-        if (allContainers.size() > 0) {
-            LinkedList<String> listKeys = new LinkedList<String>(allContainers.keySet());
-            return allContainers.get(listKeys.getLast());
+        if (activeContainers.size() > 0) {
+            return activeContainers.getLast();
         }
         return null;
     }
@@ -40,21 +66,7 @@ public class FlutterContainerManager {
         return false;
     }
 
-    public void reorderContainer(String uniqueId, FlutterViewContainer container) {
-        if (uniqueId == null || container == null) return;
-        if (allContainers.containsKey(uniqueId)) {
-            allContainers.remove(uniqueId);
-        }
-        allContainers.put(uniqueId, container);
+    public int getContainerSize() {
+        return allContainers.size();
     }
-
-    public void removeContainer(String uniqueId) {
-        if (uniqueId == null) return;
-        allContainers.remove(uniqueId);
-    }
-
-    public LinkedList<String> getContainers() {
-        return new LinkedList<String>(allContainers.keySet());
-    }
-
 }

--- a/example3.0/lib/main.dart
+++ b/example3.0/lib/main.dart
@@ -12,8 +12,14 @@ void main() {
   ///添加全局生命周期监听类
   PageVisibilityBinding.instance.addGlobalObserver(AppLifecycleObserver());
 
+  ///这里的CustomFlutterBinding调用务必不可缺少，用于控制Boost状态的resume和pause
+  CustomFlutterBinding();
   runApp(MyApp());
 }
+
+///创建一个自定义的Binding，集成和with的关系如下，里面什么都不用写
+class CustomFlutterBinding extends WidgetsFlutterBinding
+    with BoostFlutterBinding {}
 
 class MyApp extends StatefulWidget {
   @override

--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -50,8 +50,6 @@
     [super viewDidDisappear:animated];
 }
 - (void)bridge_viewWillAppear:(BOOL)animated {
-    //    [FLUTTER_APP inactive];
-    [FBLifecycle inactive ];
     [super viewWillAppear:animated];
 }
 @end

--- a/ios/Classes/container/FBLifecycle.h
+++ b/ios/Classes/container/FBLifecycle.h
@@ -26,5 +26,4 @@
 @interface FBLifecycle : NSObject
 + (void)pause;
 + (void)resume;
-+ (void)inactive;
 @end

--- a/ios/Classes/container/FBLifecycle.m
+++ b/ios/Classes/container/FBLifecycle.m
@@ -31,19 +31,15 @@
 @implementation FBLifecycle
 
 + (void)pause{
-    [[ENGINE lifecycleChannel] sendMessage:@"AppLifecycleState.paused"];
+    [[FlutterBoost instance]sendEventToFlutterWith:@"app_lifecycle_changed_key" arguments:@{@"lifecycleState":@2}];
     if(ENGINE.viewController != nil){
-        //        [(FBFlutterContainer *) ENGINE.viewController  surfaceUpdated:NO];
         ENGINE.viewController = nil;
     }
 }
 + (void)resume{
     if([UIApplication sharedApplication].applicationState == UIApplicationStateActive){
-        [[ENGINE lifecycleChannel] sendMessage:@"AppLifecycleState.resumed"];
+        [[FlutterBoost instance]sendEventToFlutterWith:@"app_lifecycle_changed_key" arguments:@{@"lifecycleState":@0}];
     }
-}
-+ (void)inactive{
-    [[ENGINE lifecycleChannel] sendMessage:@"AppLifecycleState.inactive"];
 }
 
 @end

--- a/lib/boost_lifecycle_binding.dart
+++ b/lib/boost_lifecycle_binding.dart
@@ -84,14 +84,11 @@ class BoostLifecycleBinding {
     Logger.log('boost_lifecycle: BoostLifecycleBinding.appDidEnterForeground');
     PageVisibilityBinding.instance
         .dispatchPageForgroundEvent(container.topPage.route);
-
-    BoostFlutterBinding.instance.changeAppLifecycleState(AppLifecycleState.resumed);
   }
 
   void appDidEnterBackground(BoostContainer container) {
     Logger.log('boost_lifecycle: BoostLifecycleBinding.appDidEnterBackground');
     PageVisibilityBinding.instance
         .dispatchPageBackgroundEvent(container.topPage.route);
-    BoostFlutterBinding.instance.changeAppLifecycleState(AppLifecycleState.paused);
   }
 }

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -547,8 +547,9 @@ class BoostNavigatorObserver extends NavigatorObserver {
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic> previousRoute) {
-    //handle internal route
-    if (previousRoute != null) {
+    //handle internal route but ignore dialog or abnormal route.
+    //otherwise, the normal page will be affected.
+    if (previousRoute != null && route?.settings?.name != null) {
       BoostLifecycleBinding.instance.routeDidPush(route, previousRoute);
     }
     super.didPush(route, previousRoute);
@@ -556,7 +557,7 @@ class BoostNavigatorObserver extends NavigatorObserver {
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic> previousRoute) {
-    if (previousRoute != null) {
+    if (previousRoute != null && route?.settings?.name != null) {
       BoostLifecycleBinding.instance.routeDidPop(route, previousRoute);
     }
     super.didPop(route, previousRoute);


### PR DESCRIPTION
上一次改了Flutter AppLifecycle的实现，基于前后台来控制。目前看可能基于容器数量是一个更好的方案，之前iOS也是这样实现的，有容器就resume，没有任何容器就pause。