### PR TITLE
调整 Flutter Engine 初始化流程，避免使用异步方式产生插件注册时序问题

### DIFF
--- a/ios/Classes/FlutterBoost.m
+++ b/ios/Classes/FlutterBoost.m
@@ -59,10 +59,6 @@
         
         [self.engine runWithEntrypoint:dartEntrypointFunctionName  initialRoute : initialRoute];
         
-        if(callback){
-            callback(self.engine);
-        }
-        
         Class clazz = NSClassFromString(@"GeneratedPluginRegistrant");
         SEL selector = NSSelectorFromString(@"registerWithRegistry:");
         if (clazz && selector && self.engine) {
@@ -73,6 +69,10 @@
         
         self.plugin= [FlutterBoostPlugin getPlugin:self.engine];
         self.plugin.delegate=delegate;
+        
+        if(callback){
+            callback(self.engine);
+        }
     };
     
     if ([NSThread isMainThread]){


### PR DESCRIPTION
调整 Flutter Engine 初始化流程，避免使用异步方式产生插件注册时序问题