### PR TITLE
重构内部路由Pop时的结果回传逻辑

### DIFF
--- a/example/lib/case/media_query.dart
+++ b/example/lib/case/media_query.dart
@@ -1,12 +1,7 @@
-import 'dart:async';
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/basic.dart';
 import 'package:flutter/src/widgets/container.dart';
-import 'package:image_picker/image_picker.dart';
-import 'package:video_player/video_player.dart';
+import 'package:flutter_boost/boost_navigator.dart';
 import 'package:flutter_boost/logger.dart';
 
 class MediaQueryRouteWidget extends StatefulWidget {
@@ -61,19 +56,48 @@ class _MediaQueryRouteWidgetState extends State<MediaQueryRouteWidget> {
         '${MediaQuery.of(context).size.height} uniqueId=${widget.uniqueId}');
 
     return Scaffold(
-        appBar: AppBar(
-          title: Text('media query demo'),
-        ),
-        body: Container(
-            height: 500,
-            margin: const EdgeInsets.all(24.0),
-            child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text('top: ${MediaQuery.of(context).padding.top}'),
-                  Text('bottom: ${MediaQuery.of(context).padding.bottom}'),
-                  Text('width: ${MediaQuery.of(context).size.width}'),
-                  Text('height: ${MediaQuery.of(context).size.height}')
-                ])));
+      appBar: AppBar(
+        title: Text('media query demo'),
+      ),
+      body: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Container(
+                height: 500,
+                margin: const EdgeInsets.all(24.0),
+                child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text('top: ${MediaQuery.of(context).padding.top}'),
+                      Text('bottom: ${MediaQuery.of(context).padding.bottom}'),
+                      Text('width: ${MediaQuery.of(context).size.width}'),
+                      Text('height: ${MediaQuery.of(context).size.height}')
+                    ])),
+            InkWell(
+              child: Container(
+                  padding: const EdgeInsets.all(8.0),
+                  margin: const EdgeInsets.all(8.0),
+                  color: Colors.yellow,
+                  child: Text(
+                    'Pop with BoostNavigator',
+                    style: TextStyle(fontSize: 22.0, color: Colors.black),
+                  )),
+              onTap: () => BoostNavigator.instance
+                  .pop('I am BoostNavigator from MediaQueryRouteWidget!'),
+            ),
+            InkWell(
+              child: Container(
+                  padding: const EdgeInsets.all(8.0),
+                  margin: const EdgeInsets.all(8.0),
+                  color: Colors.yellow,
+                  child: Text(
+                    'Pop with Navigator',
+                    style: TextStyle(fontSize: 22.0, color: Colors.black),
+                  )),
+              onTap: () => Navigator.of(context)
+                  .pop('I am Navigator from MediaQueryRouteWidget too!'),
+            ),
+          ]),
+    );
   }
 }

--- a/example/lib/case/transparent_widget.dart
+++ b/example/lib/case/transparent_widget.dart
@@ -11,7 +11,8 @@ class TransparentWidget extends StatelessWidget {
         alignment: Alignment.bottomCenter,
         child: GestureDetector(
           onTap: () {
-            BoostNavigator.instance.pop();
+            // BoostNavigator.instance.pop();
+            Navigator.of(context).pop("I'm quit!");
           },
           child: Container(
             height: 300,

--- a/example/lib/flutter_page.dart
+++ b/example/lib/flutter_page.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_boost_example/case/platform_view.dart';
 import 'package:flutter_boost/boost_navigator.dart';
-import 'package:flutter_boost/page_visibility.dart';
 import 'package:flutter_boost/logger.dart';
-import 'package:flutter_boost_example/case/transparent_widget.dart';
+import 'package:flutter_boost/page_visibility.dart';
 
 class FlutterRouteWidget extends StatefulWidget {
   FlutterRouteWidget({this.params, this.message, this.uniqueId});
@@ -197,16 +195,19 @@ class _FlutterRouteWidgetState extends State<FlutterRouteWidget>
                   onTap: () => BoostNavigator.instance
                       .push("willPop", withContainer: true)),
               InkWell(
-                  child: Container(
-                      padding: const EdgeInsets.all(8.0),
-                      margin: const EdgeInsets.all(8.0),
-                      color: Colors.yellow,
-                      child: Text(
-                        'mediaquery demo',
-                        style: TextStyle(fontSize: 22.0, color: Colors.black),
-                      )),
-                  onTap: () => BoostNavigator.instance
-                      .push("mediaquery", withContainer: true)),
+                child: Container(
+                    padding: const EdgeInsets.all(8.0),
+                    margin: const EdgeInsets.all(8.0),
+                    color: Colors.yellow,
+                    child: Text(
+                      'mediaquery demo(withContainer=false)',
+                      style: TextStyle(fontSize: 22.0, color: Colors.black),
+                    )),
+                onTap: () => BoostNavigator.instance
+                    .push("mediaquery", withContainer: false)
+                    .then((value) =>
+                        print('xlog, mediaquery, Return Value:$value')),
+              ),
               InkWell(
                 child: Container(
                     padding: const EdgeInsets.all(8.0),
@@ -217,8 +218,11 @@ class _FlutterRouteWidgetState extends State<FlutterRouteWidget>
                       style: TextStyle(fontSize: 22.0, color: Colors.black),
                     )),
                 onTap: () {
-                  Navigator.push<dynamic>(context,
-                      MaterialPageRoute<dynamic>(builder: (_) => PushWidget()));
+                  Navigator.push<dynamic>(
+                      context,
+                      MaterialPageRoute<dynamic>(
+                          builder: (_) => PushWidget())).then((value) =>
+                      print('xlog, PushWidget, Return Value: $value'));
                 },
               ),
               InkWell(
@@ -288,7 +292,8 @@ class _PushWidgetState extends State<PushWidget> {
               icon: const Icon(Icons.arrow_back),
               // 如果有抽屉的话的就打开
               onPressed: () {
-                BoostNavigator.instance.pop();
+                // BoostNavigator.instance.pop('Hello, I am from PushWidget.');
+                Navigator.of(context).pop('Hello, I am from PushWidget.');
               },
               // 显示描述信息
               tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
@@ -298,8 +303,8 @@ class _PushWidgetState extends State<PushWidget> {
         ),
         body: Container(
           color: Colors.red,
-          width: 100,
-          height: 100,
+          width: 300,
+          height: 300,
         ));
   }
 }

--- a/lib/boost_container.dart
+++ b/lib/boost_container.dart
@@ -29,6 +29,9 @@ class BoostContainer extends ChangeNotifier {
   /// Number of pages
   int numPages() => pages.length;
 
+  NavigatorState get navigator => _navKey.currentState;
+  final GlobalKey<NavigatorState> _navKey = GlobalKey<NavigatorState>();
+
   Future<T> addPage<T extends Object>(BoostPage page) {
     if (page != null) {
       _pages.add(page);
@@ -45,9 +48,6 @@ class BoostContainer extends ChangeNotifier {
       notifyListeners();
     }
   }
-
-  NavigatorState get navigator => _navKey.currentState;
-  final GlobalKey<NavigatorState> _navKey = GlobalKey<NavigatorState>();
 
   @override
   String toString() =>

--- a/lib/boost_container.dart
+++ b/lib/boost_container.dart
@@ -124,7 +124,6 @@ class BoostContainerState extends State<BoostContainerWidget> {
           pages: List<Page<dynamic>>.of(widget.container.pages),
           onPopPage: (route, result) {
             if (route.didPop(result)) {
-              print('xlog, #onPopPage, result:$result, route:$route');
               assert(route.settings is BoostPage);
               _updatePagesList(route.settings as BoostPage, result);
               return true;

--- a/lib/boost_flutter_router_api.dart
+++ b/lib/boost_flutter_router_api.dart
@@ -18,7 +18,7 @@ class BoostFlutterRouterApi extends FlutterRouterApi {
 
   @override
   void pushRoute(CommonParams arg) {
-    appState.pushWithContainer(arg.pageName,
+    appState.pushContainer(arg.pageName,
         uniqueId: arg.uniqueId,
         arguments:
             Map<String, dynamic>.from(arg.arguments ?? <String, dynamic>{}));

--- a/lib/boost_flutter_router_api.dart
+++ b/lib/boost_flutter_router_api.dart
@@ -18,11 +18,10 @@ class BoostFlutterRouterApi extends FlutterRouterApi {
 
   @override
   void pushRoute(CommonParams arg) {
-    appState.push(arg.pageName,
+    appState.pushWithContainer(arg.pageName,
         uniqueId: arg.uniqueId,
         arguments:
-            Map<String, dynamic>.from(arg.arguments ?? <String, dynamic>{}),
-        withContainer: true);
+            Map<String, dynamic>.from(arg.arguments ?? <String, dynamic>{}));
   }
 
   @override

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -346,7 +346,7 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
           ..pageName = container.pageInfo.pageName
           ..uniqueId = container.pageInfo.uniqueId
           ..arguments =
-              (result is Map<String, dynamic>) ? result : {'args': result};
+              (result is Map<String, dynamic>) ? result : <String, dynamic>{};
         await nativeRouterApi.popRoute(params);
       }
     } else {

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -221,10 +221,9 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
             var arguments = Map<String, dynamic>.from(
                 route['arguments'] ?? <String, dynamic>{});
             withContainer
-                ? pushWithContainer(pageName,
+                ? pushContainer(pageName,
                     uniqueId: uniqueId, arguments: arguments)
-                : _pushWithoutContainer(pageName,
-                    uniqueId: uniqueId, arguments: arguments);
+                : _pushPage(pageName, uniqueId: uniqueId, arguments: arguments);
             withContainer = false;
           }
         }
@@ -252,12 +251,11 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
       _pendingResult[uniqueId] = completer;
       return completer.future;
     } else {
-      return _pushWithoutContainer(pageName,
-          uniqueId: uniqueId, arguments: arguments);
+      return _pushPage(pageName, uniqueId: uniqueId, arguments: arguments);
     }
   }
 
-  Future<T> _pushWithoutContainer<T extends Object>(String pageName,
+  Future<T> _pushPage<T extends Object>(String pageName,
       {String uniqueId, Map<String, dynamic> arguments}) {
     Logger.log('pushWithoutContainer, uniqueId=$uniqueId, name=$pageName,'
         ' arguments:$arguments, $topContainer');
@@ -270,7 +268,7 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     return topContainer.addPage(BoostPage.create(pageInfo));
   }
 
-  void pushWithContainer(String pageName,
+  void pushContainer(String pageName,
       {String uniqueId, Map<String, dynamic> arguments}) {
     _cancelActivePointers();
     final existed = _findContainerByUniqueId(uniqueId);
@@ -297,7 +295,7 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
       // Add a new overlay entry with this container
       refreshOnPush(container);
     }
-    Logger.log('pushWithContainer, uniqueId=$uniqueId, existed=$existed,'
+    Logger.log('pushContainer, uniqueId=$uniqueId, existed=$existed,'
         ' arguments:$arguments, $containers');
   }
 

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -223,7 +223,7 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
             withContainer
                 ? pushContainer(pageName,
                     uniqueId: uniqueId, arguments: arguments)
-                : _pushPage(pageName, uniqueId: uniqueId, arguments: arguments);
+                : pushPage(pageName, uniqueId: uniqueId, arguments: arguments);
             withContainer = false;
           }
         }
@@ -251,13 +251,13 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
       _pendingResult[uniqueId] = completer;
       return completer.future;
     } else {
-      return _pushPage(pageName, uniqueId: uniqueId, arguments: arguments);
+      return pushPage(pageName, uniqueId: uniqueId, arguments: arguments);
     }
   }
 
-  Future<T> _pushPage<T extends Object>(String pageName,
+  Future<T> pushPage<T extends Object>(String pageName,
       {String uniqueId, Map<String, dynamic> arguments}) {
-    Logger.log('pushWithoutContainer, uniqueId=$uniqueId, name=$pageName,'
+    Logger.log('pushPage, uniqueId=$uniqueId, name=$pageName,'
         ' arguments:$arguments, $topContainer');
     final pageInfo = PageInfo(
         pageName: pageName,


### PR DESCRIPTION
* 1. 通过BoostNavigator打开的内部路由，也可通过原生Navigator.pop关闭，并且正确传递返回值
* 2. 解决内部路由场景下pending Completer可能泄漏的问题