### PR TITLE
修复刷帧逻辑bug，确保刷帧正常进行，从而让State正常dispose

### DIFF
--- a/lib/overlay_entry.dart
+++ b/lib/overlay_entry.dart
@@ -50,6 +50,10 @@ void refreshSpecificOverlayEntries(
         //remove from the list and overlay
         _lastEntries.remove(entryToRemove);
         entryToRemove.remove();
+        // https://github.com/alibaba/flutter_boost/issues/1056
+        // Ensure this frame is refreshed after schedule frame,
+        // otherwise the PageState.dispose may not be called
+        SchedulerBinding.instance.scheduleWarmUpFrame();
       }
       break;
     case BoostSpecificEntryRefreshMode.moveToTop:
@@ -63,15 +67,6 @@ void refreshSpecificOverlayEntries(
       existingEntry.remove();
       overlayState.insert(existingEntry);
       break;
-  }
-
-  // https://github.com/alibaba/flutter_boost/issues/1056
-  // Ensure this frame is refreshed after schedule frame,
-  // otherwise the PageState.dispose may not be called
-  final hasScheduledFrame = SchedulerBinding.instance.hasScheduledFrame;
-  final framesEnabled = SchedulerBinding.instance.framesEnabled;
-  if (hasScheduledFrame || !framesEnabled) {
-    SchedulerBinding.instance.scheduleWarmUpFrame();
   }
 }
 

--- a/lib/overlay_entry.dart
+++ b/lib/overlay_entry.dart
@@ -33,9 +33,6 @@ void refreshSpecificOverlayEntries(
     return;
   }
 
-  final hasScheduledFrame = SchedulerBinding.instance.hasScheduledFrame;
-  final framesEnabled = SchedulerBinding.instance.framesEnabled;
-
   //deal with different situation
   switch (mode) {
     case BoostSpecificEntryRefreshMode.add:
@@ -71,6 +68,8 @@ void refreshSpecificOverlayEntries(
   // https://github.com/alibaba/flutter_boost/issues/1056
   // Ensure this frame is refreshed after schedule frame,
   // otherwise the PageState.dispose may not be called
+  final hasScheduledFrame = SchedulerBinding.instance.hasScheduledFrame;
+  final framesEnabled = SchedulerBinding.instance.framesEnabled;
   if (hasScheduledFrame || !framesEnabled) {
     SchedulerBinding.instance.scheduleWarmUpFrame();
   }
@@ -94,14 +93,13 @@ void refreshAllOverlayEntries(List<BoostContainer> containers) {
           (container) => _ContainerOverlayEntry(container))
       .toList(growable: true);
 
-  final hasScheduledFrame = SchedulerBinding.instance.hasScheduledFrame;
-  final framesEnabled = SchedulerBinding.instance.framesEnabled;
-
   overlayState.insertAll(_lastEntries);
 
   // https://github.com/alibaba/flutter_boost/issues/1056
   // Ensure this frame is refreshed after schedule frame，
   // otherwise the PageState.dispose may not be called
+  final hasScheduledFrame = SchedulerBinding.instance.hasScheduledFrame;
+  final framesEnabled = SchedulerBinding.instance.framesEnabled;
   if (hasScheduledFrame || !framesEnabled) {
     SchedulerBinding.instance.scheduleWarmUpFrame();
   }


### PR DESCRIPTION
关联issue：#1246

先说现象（我只看了iOS的），原生容器可以正常dealloc，但是flutter层的dispose并没有调用，像issue说的那样，下一次push的时候才会调用dispose。

之前改过一次，但是我认为其实有点问题，之前的`hasScheduledFrame`和`framesEnabled`变量的生成在overlay进行insert/remove之前进行记录，但是我认为应该在overlay进行insert/remove之后才对这两个变量进行记录才是合适的，因为overlay的insert/remove方法会调用内部的setState，而setState才会对vsync信号进行订阅，从而保证触发`SchedulerBinding.instance.scheduleWarmUpFrame();`的逻辑，所以如果这两个变量，也就是`hasScheduledFrame`和`framesEnabled`在overlay进行操作之前就记录的话，其实就走不到if判断里面的`SchedulerBinding.instance.scheduleWarmUpFrame();`逻辑了。当然，如果更暴力点，直接无需判断直接调`SchedulerBinding.instance.scheduleWarmUpFrame();`貌似也没有问题