### PR TITLE
[Android] Flutter页面隐藏时，断开PlatformChannel，避免隐藏页面的消息影响当前页面，例如，setSystem…

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -94,6 +94,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
         assert (flutterView != null);
         ActivityAndFragmentPatch.onPauseDetachFromFlutterEngine(flutterView, getFlutterEngine());
         getFlutterEngine().getActivityControlSurface().detachFromActivity();
+        platformPlugin.destroy();
         platformPlugin = null;
         getFlutterEngine().getLifecycleChannel().appIsResumed();
     }

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -194,6 +194,7 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     private void didFragmentHide() {
         FlutterBoost.instance().getPlugin().onContainerDisappeared(this);
         ActivityAndFragmentPatch.onPauseDetachFromFlutterEngine(flutterView, getFlutterEngine());
+        platformPlugin.destroy();
         platformPlugin = null;
     }
 


### PR DESCRIPTION
…UiOverlayStyle。如果业务修改了页面显示与隐藏(onResume/onPause)逻辑，需要确保其的时序正确，否则可能出现PlatformChannel消息丢失的问题。

* 例如，在Native页面和Flutter页面之间实现沉浸式状态栏的场景，如果Flutter页面隐藏时，不断开PlatformChannel，原生的setSystemUiOverlayStyle消息会影响当前Native的状态栏。