### PR TITLE
[Android] 只有在必要时才执行引擎的attach/detach操作，解决半透明弹窗背景黑/白屏、传参丢失、请求权限失败，以及ima…

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterContainerManager.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterContainerManager.java
@@ -24,11 +24,13 @@ public class FlutterContainerManager {
     private final Map<String, FlutterViewContainer> allContainers = new HashMap<>();
     private final LinkedList<FlutterViewContainer> activeContainers = new LinkedList<>();
 
+    // onContainerCreated
     public void addContainer(String uniqueId, FlutterViewContainer container) {
         allContainers.put(uniqueId, container);
-        if (DEBUG) Log.e(TAG, "#addContainer:" + toString());
+        if (DEBUG) Log.d(TAG, "#addContainer:" + toString());
     }
 
+    // onContainerAppeared
     public void activateContainer(String uniqueId, FlutterViewContainer container) {
         if (uniqueId == null || container == null) return;
         assert (allContainers.containsKey(uniqueId));
@@ -37,14 +39,15 @@ public class FlutterContainerManager {
             activeContainers.remove(container);
         }
         activeContainers.add(container);
-        if (DEBUG) Log.e(TAG, "#activateContainer:" + toString());
+        if (DEBUG) Log.d(TAG, "#activateContainer:" + toString());
     }
 
+    // onContainerDestroyed
     public void removeContainer(String uniqueId) {
         if (uniqueId == null) return;
         FlutterViewContainer container = allContainers.remove(uniqueId);
         activeContainers.remove(container);
-        if (DEBUG) Log.e(TAG, "#removeContainer:" + toString());
+        if (DEBUG) Log.d(TAG, "#removeContainer:" + toString());
     }
 
 

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterViewContainer.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterViewContainer.java
@@ -13,4 +13,5 @@ public interface FlutterViewContainer {
     Map<String, Object> getUrlParams();
     String getUniqueId();
     void finishContainer(Map<String, Object> result);
+    default void detachFromEngineIfNeeded() {}
 }

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostView.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostView.java
@@ -6,11 +6,10 @@ import android.util.Log;
 import android.view.View;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.idlefish.flutterboost.FlutterBoost;
-import com.idlefish.flutterboost.FlutterBoostPlugin;
 import com.idlefish.flutterboost.FlutterBoostUtils;
+import com.idlefish.flutterboost.Messages;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -177,7 +176,7 @@ public class FlutterBoostView extends LifecycleView implements FlutterViewContai
     }
 
     public void onBackPressed() {
-        FlutterBoost.instance().getPlugin().popRoute(null, null);
+        FlutterBoost.instance().getPlugin().popRoute(null, (Messages.FlutterRouterApi.Reply<Void>) null);
     }
 
     @Override

--- a/example/lib/case/webview_flutter_demo.dart
+++ b/example/lib/case/webview_flutter_demo.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter_boost/boost_navigator.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 class WebViewExample extends StatefulWidget {
@@ -17,8 +18,41 @@ class WebViewExampleState extends State<WebViewExample> {
 
   @override
   Widget build(BuildContext context) {
-    return WebView(
-      initialUrl: 'https://github.com/alibaba/flutter_boost',
-    );
+    return MaterialApp(
+        home: Scaffold(
+            appBar: AppBar(
+              title: const Text('WebView Example'),
+            ),
+            body: Container(
+                child: Column(children: <Widget>[
+              Container(
+                margin: const EdgeInsets.all(10.0),
+                child: TextFormField(
+                  decoration: InputDecoration(
+                      border: UnderlineInputBorder(),
+                      labelText: 'Enter something...'),
+                ),
+              ),
+              InkWell(
+                child: Container(
+                    margin: const EdgeInsets.all(10.0),
+                    color: Colors.yellow,
+                    child: Text(
+                      'open flutter page',
+                      style: TextStyle(fontSize: 22.0, color: Colors.black),
+                    )),
+                onTap: () => BoostNavigator.instance
+                    .push("flutterPage", withContainer: true),
+              ),
+              Expanded(
+                  child: Container(
+                margin: const EdgeInsets.all(10.0),
+                decoration:
+                    BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+                child: WebView(
+                  initialUrl: 'https://github.com/alibaba/flutter_boost',
+                ),
+              )),
+            ]))));
   }
 }


### PR DESCRIPTION
…ge_picker插件不可用等问题

 * 之前：只要FlutterViewContainer收到onResume/onPause事件，就会执行引擎的attach/detach操作
 * 现在：只有引擎的FlutterView真正发生切换时，才执行attach/detach操作（前后台事件和Native页面引起的onResume/onPause回调，并没有FlutterView的切换）