### PR TITLE
[Android] 解决特定场景下半透明弹窗背景黑/白屏、传参丢失、请求权限失败，以及image_picker插件不可用等问题

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
@@ -64,10 +64,12 @@ public class FlutterBoost {
         FlutterEngine engine = getEngine();
         if (engine == null) {
             engine = new FlutterEngine(application, options.shellArgs());
+            // Cache the created FlutterEngine in the FlutterEngineCache.
             FlutterEngineCache.getInstance().put(ENGINE_ID, engine);
         }
 
         if (!engine.getDartExecutor().isExecutingDart()) {
+            // Pre-warm the cached FlutterEngine.
             engine.getNavigationChannel().setInitialRoute(options.initialRoute());
             engine.getDartExecutor().executeDartEntrypoint(new DartExecutor.DartEntrypoint(
                     FlutterMain.findAppBundlePath(), options.dartEntrypoint()));

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 
 import com.idlefish.flutterboost.FlutterBoost;
 import com.idlefish.flutterboost.FlutterBoostUtils;
@@ -15,7 +16,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import io.flutter.Log;
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.android.RenderMode;
@@ -151,6 +151,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
             isDisplayingFlutterUiField.setBoolean(flutterRenderer, false);
             assert(!flutterRenderer.isDisplayingFlutterUi());
         } catch (Exception e) {
+            Log.e(TAG, "You *should* keep fields in io.flutter.embedding.engine.renderer.FlutterRenderer.");
             e.printStackTrace();
         }
     }

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -10,6 +10,7 @@ import com.idlefish.flutterboost.FlutterBoost;
 import com.idlefish.flutterboost.FlutterBoostUtils;
 import com.idlefish.flutterboost.Messages;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -19,6 +20,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.android.RenderMode;
 import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.plugin.platform.PlatformPlugin;
 
 import static com.idlefish.flutterboost.containers.FlutterActivityLaunchConfigs.ACTIVITY_RESULT_KEY;
@@ -37,14 +39,14 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
     private final String who = UUID.randomUUID().toString();
     private FlutterView flutterView;
     private PlatformPlugin platformPlugin;
-    private boolean isAttachedToActivity = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         flutterView = FlutterBoostUtils.findFlutterView(getWindow().getDecorView());
+        flutterView.detachFromFlutterEngine(); // Avoid failure when attaching to engine in |onResume|.
         FlutterBoost.instance().getPlugin().onContainerCreated(this);
-        if (DEBUG) Log.e(TAG, "#onCreate: " + this);
+        if (DEBUG) Log.d(TAG, "#onCreate: " + this);
     }
 
     // @Override
@@ -55,6 +57,27 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
          * The idea here is to avoid releasing delegate when
          * a new FlutterActivity is attached in Flutter2.0.
          */
+        if (DEBUG) Log.d(TAG, "#detachFromFlutterEngine: " + this);
+    }
+
+    @Override
+    // This method is called right before the activity's onPause() callback.
+    public void onUserLeaveHint() {
+        super.onUserLeaveHint();
+        if (DEBUG) Log.d(TAG, "#onUserLeaveHint: " + this);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        if (DEBUG) Log.d(TAG, "#onStart: " + this);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        getFlutterEngine().getLifecycleChannel().appIsResumed();
+        if (DEBUG) Log.d(TAG, "#onStop: " + this);
     }
 
     @Override
@@ -68,20 +91,14 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
                 return;
             }
         }
+        // try to detach prevous container from the engine.
+        FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
+        if (top != null && top != this) top.detachFromEngineIfNeeded();
 
-        platformPlugin = new PlatformPlugin(getActivity(), getFlutterEngine().getPlatformChannel());
-        attachToActivity();
+        performAttach();
         FlutterBoost.instance().getPlugin().onContainerAppeared(this);
-        assert (flutterView != null);
-        flutterView.attachToFlutterEngine(getFlutterEngine());
-        if (DEBUG) Log.e(TAG, "#onResume: " + this);
-    }
-
-    @Override
-    protected void onStop() {
-        super.onStop();
         getFlutterEngine().getLifecycleChannel().appIsResumed();
-        if (DEBUG) Log.e(TAG, "#onStop: " + this);
+        if (DEBUG) Log.d(TAG, "#onResume: " + this);
     }
 
     @Override
@@ -97,13 +114,49 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
         }
 
         FlutterBoost.instance().getPlugin().onContainerDisappeared(this);
-        assert (flutterView != null);
-        flutterView.detachFromFlutterEngine();
-        detachFromActivity();
-        platformPlugin.destroy();
-        platformPlugin = null;
         getFlutterEngine().getLifecycleChannel().appIsResumed();
-        if (DEBUG) Log.e(TAG, "#onPause: " + this);
+
+        // We defer |performDetach| call to new Flutter container's |onResume|.
+        fixBlankScreenWhenActivityTransition();
+        if (DEBUG) Log.d(TAG, "#onPause: " + this);
+    }
+
+    private void performAttach() {
+        if (platformPlugin == null) {
+            platformPlugin = new PlatformPlugin(getActivity(), getFlutterEngine().getPlatformChannel());
+            getFlutterEngine().getActivityControlSurface().attachToActivity(getActivity(), getLifecycle());
+            assert (flutterView != null);
+            flutterView.attachToFlutterEngine(getFlutterEngine());
+            if (DEBUG) Log.d(TAG, "#performAttach: " + this);
+        }
+    }
+
+    private void performDetach() {
+        if (platformPlugin != null) {
+            assert (flutterView != null);
+            flutterView.detachFromFlutterEngine();
+            getFlutterEngine().getActivityControlSurface().detachFromActivity();
+            platformPlugin.destroy();
+            platformPlugin = null;
+            if (DEBUG) Log.d(TAG, "#performDetach: " + this);
+        }
+    }
+
+    private void fixBlankScreenWhenActivityTransition() {
+        try {
+            FlutterRenderer flutterRenderer = getFlutterEngine().getRenderer();
+            Field isDisplayingFlutterUiField = FlutterRenderer.class.getDeclaredField("isDisplayingFlutterUi");
+            isDisplayingFlutterUiField.setAccessible(true);
+            isDisplayingFlutterUiField.setBoolean(flutterRenderer, false);
+            assert(!flutterRenderer.isDisplayingFlutterUi());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void detachFromEngineIfNeeded() {
+        performDetach();
     }
 
     @Override
@@ -113,7 +166,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
         super.onDestroy();
         engine.getLifecycleChannel().appIsResumed();
         FlutterBoost.instance().getPlugin().onContainerDestroyed(this);
-        if (DEBUG) Log.e(TAG, "#onDestroy: " + this);
+        if (DEBUG) Log.d(TAG, "#onDestroy: " + this);
     }
 
     @Override
@@ -146,6 +199,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
     public void onBackPressed() {
         // Intercept the user's press of the back key.
         FlutterBoost.instance().getPlugin().popRoute(null, (Messages.FlutterRouterApi.Reply<Void>) null);
+        if (DEBUG) Log.d(TAG, "#onBackPressed: " + this);
     }
 
     @Override
@@ -167,6 +221,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
             setResult(Activity.RESULT_OK, intent);
         }
         finish();
+        if (DEBUG) Log.d(TAG, "#finishContainer: " + this);
     }
 
     @Override
@@ -194,38 +249,6 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
     @Override
     public String getCachedEngineId() {
       return FlutterBoost.ENGINE_ID;
-    }
-
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        // lifecycle is onRequestPermissionsResult->onResume
-        attachToActivity();
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        // lifecycle is onActivityResult->onResume
-        attachToActivity();
-        super.onActivityResult(requestCode, resultCode, data);
-        if (DEBUG) Log.e(TAG, "#onActivityResult: " + this);
-    }
-
-    private void attachToActivity() {
-        if (isAttachedToActivity) {
-            return;
-        }
-        isAttachedToActivity = true;
-        getFlutterEngine().getActivityControlSurface().attachToActivity(getActivity(), getLifecycle());
-    }
-
-    private void detachFromActivity() {
-        if (!isAttachedToActivity) {
-            return;
-        }
-        isAttachedToActivity = false;
-        getFlutterEngine().getActivityControlSurface().detachFromActivity();
     }
 
     public static class CachedEngineIntentBuilder {

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -117,7 +117,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
         getFlutterEngine().getLifecycleChannel().appIsResumed();
 
         // We defer |performDetach| call to new Flutter container's |onResume|.
-        fixBlankScreenWhenActivityTransition();
+        setIsFlutterUiDisplayed(false);
         if (DEBUG) Log.d(TAG, "#onPause: " + this);
     }
 
@@ -142,7 +142,8 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
         }
     }
 
-    private void fixBlankScreenWhenActivityTransition() {
+    // Fix black screen when activity transition
+    private void setIsFlutterUiDisplayed(boolean isDisplayed) {
         try {
             FlutterRenderer flutterRenderer = getFlutterEngine().getRenderer();
             Field isDisplayingFlutterUiField = FlutterRenderer.class.getDeclaredField("isDisplayingFlutterUi");

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterContainerManager.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterContainerManager.java
@@ -24,11 +24,13 @@ public class FlutterContainerManager {
     private final Map<String, FlutterViewContainer> allContainers = new HashMap<>();
     private final LinkedList<FlutterViewContainer> activeContainers = new LinkedList<>();
 
+    // onContainerCreated
     public void addContainer(String uniqueId, FlutterViewContainer container) {
         allContainers.put(uniqueId, container);
-        if (DEBUG) Log.e(TAG, "#addContainer:" + toString());
+        if (DEBUG) Log.d(TAG, "#addContainer:" + toString());
     }
 
+    // onContainerAppeared
     public void activateContainer(String uniqueId, FlutterViewContainer container) {
         if (uniqueId == null || container == null) return;
         assert (allContainers.containsKey(uniqueId));
@@ -37,14 +39,15 @@ public class FlutterContainerManager {
             activeContainers.remove(container);
         }
         activeContainers.add(container);
-        if (DEBUG) Log.e(TAG, "#activateContainer:" + toString());
+        if (DEBUG) Log.d(TAG, "#activateContainer:" + toString());
     }
 
+    // onContainerDestroyed
     public void removeContainer(String uniqueId) {
         if (uniqueId == null) return;
         FlutterViewContainer container = allContainers.remove(uniqueId);
         activeContainers.remove(container);
-        if (DEBUG) Log.e(TAG, "#removeContainer:" + toString());
+        if (DEBUG) Log.d(TAG, "#removeContainer:" + toString());
     }
 
 

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterViewContainer.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterViewContainer.java
@@ -13,4 +13,5 @@ public interface FlutterViewContainer {
     Map<String, Object> getUrlParams();
     String getUniqueId();
     void finishContainer(Map<String, Object> result);
+    default void detachFromEngineIfNeeded() {}
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -46,6 +46,21 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+
+            // Enables code shrinking, obfuscation, and optimization for only
+            // your project's release build type.
+            minifyEnabled true
+
+            // Enables resource shrinking, which is performed by the
+            // Android Gradle plugin.
+            shrinkResources true
+
+            // Includes the default ProGuard rules files that are packaged with
+            // the Android Gradle plugin. To learn more, go to the section about
+            // R8 configuration files.
+            proguardFiles getDefaultProguardFile(
+                    'proguard-android-optimize.txt'),
+                    'proguard-rules.pro'
         }
     }
 }
@@ -53,7 +68,7 @@ android {
 flutter {
     source '../..'
 }
- 
+
 dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostView.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostView.java
@@ -6,11 +6,10 @@ import android.util.Log;
 import android.view.View;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.idlefish.flutterboost.FlutterBoost;
-import com.idlefish.flutterboost.FlutterBoostPlugin;
 import com.idlefish.flutterboost.FlutterBoostUtils;
+import com.idlefish.flutterboost.Messages;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -177,7 +176,7 @@ public class FlutterBoostView extends LifecycleView implements FlutterViewContai
     }
 
     public void onBackPressed() {
-        FlutterBoost.instance().getPlugin().popRoute(null, null);
+        FlutterBoost.instance().getPlugin().popRoute(null, (Messages.FlutterRouterApi.Reply<Void>) null);
     }
 
     @Override

--- a/example/lib/case/webview_flutter_demo.dart
+++ b/example/lib/case/webview_flutter_demo.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter_boost/boost_navigator.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 class WebViewExample extends StatefulWidget {
@@ -17,8 +18,41 @@ class WebViewExampleState extends State<WebViewExample> {
 
   @override
   Widget build(BuildContext context) {
-    return WebView(
-      initialUrl: 'https://github.com/alibaba/flutter_boost',
-    );
+    return MaterialApp(
+        home: Scaffold(
+            appBar: AppBar(
+              title: const Text('WebView Example'),
+            ),
+            body: Container(
+                child: Column(children: <Widget>[
+              Container(
+                margin: const EdgeInsets.all(10.0),
+                child: TextFormField(
+                  decoration: InputDecoration(
+                      border: UnderlineInputBorder(),
+                      labelText: 'Enter something...'),
+                ),
+              ),
+              InkWell(
+                child: Container(
+                    margin: const EdgeInsets.all(10.0),
+                    color: Colors.yellow,
+                    child: Text(
+                      'open flutter page',
+                      style: TextStyle(fontSize: 22.0, color: Colors.black),
+                    )),
+                onTap: () => BoostNavigator.instance
+                    .push("flutterPage", withContainer: true),
+              ),
+              Expanded(
+                  child: Container(
+                margin: const EdgeInsets.all(10.0),
+                decoration:
+                    BoxDecoration(border: Border.all(color: Colors.blueAccent)),
+                child: WebView(
+                  initialUrl: 'https://github.com/alibaba/flutter_boost',
+                ),
+              )),
+            ]))));
   }
 }


### PR DESCRIPTION
 issue: #1274 、#1205

 * 之前：只要FlutterViewContainer收到onResume/onPause事件（包括切后台，打开Native页面），都会执行引擎的attach/detach操作
 * 现在：只有引擎的FlutterView真正发生切换时，才执行attach/detach操作（前后台事件和Native页面引起的onResume/onPause回调，并没有FlutterView的切换）

 * 注：将detach操作从旧Activity的onPause推迟到新Activity的onResume时，两个Activity间的切换动画会闪黑一下（为了不修改引擎，暂时通过Java反射修复）。