### PR TITLE
[fix] 过滤非StandardMessageCodec可处理的数据，修复#1248

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostDelegate.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostDelegate.java
@@ -1,6 +1,11 @@
 package com.idlefish.flutterboost;
 
+import android.content.Intent;
+
+import java.util.Map;
+
 public interface FlutterBoostDelegate {
     void pushNativeRoute(FlutterBoostRouteOptions options);
     void pushFlutterRoute(FlutterBoostRouteOptions options);
+    Map<Object, Object> handleActivityResult(Intent intent);
 }

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -301,7 +301,7 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
                 if (null != pageName) {
                     params.setPageName(pageName);
                     if (intent != null) {
-                        Map<Object, Object> result = FlutterBoostUtils.bundleToMap(intent.getExtras());
+                        Map<Object, Object> result = delegate.handleActivityResult(intent);
                         params.setArguments(result);
                     }
                     channel.onNativeResult(params, reply -> {

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostUtils.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostUtils.java
@@ -5,6 +5,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -44,11 +45,25 @@ public class FlutterBoostUtils {
             Object value = bundle.get(key);
             if(value instanceof Bundle) {
                 map.put(key, bundleToMap(bundle.getBundle(key)));
-            } else if (value != null){
+            } else if (isStandardMessageCodecType(value)) {
                 map.put(key, value);
             }
         }
         return map;
+    }
+
+    private static boolean isStandardMessageCodecType(Object value) {
+        return  (value instanceof Boolean
+                || value instanceof Number
+                || value instanceof String
+                || value instanceof byte[]
+                || value instanceof int[]
+                || value instanceof long[]
+                || value instanceof double[]
+                || value instanceof String[]
+                || (value instanceof List && ((List<?>) value).size() > 0 && isStandardMessageCodecType(((List<?>) value).get(0)))
+                || (value instanceof Map && ((Map<?, ?>) value).size() > 0 && isStandardMessageCodecType(((Map<?, ?>) value).values().toArray()[0]))
+        );
     }
 
     public static FlutterView findFlutterView(View view) {

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/MyFlutterBoostDelegate.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/MyFlutterBoostDelegate.java
@@ -5,7 +5,10 @@ import android.content.Intent;
 import com.idlefish.flutterboost.FlutterBoost;
 import com.idlefish.flutterboost.FlutterBoostDelegate;
 import com.idlefish.flutterboost.FlutterBoostRouteOptions;
+import com.idlefish.flutterboost.FlutterBoostUtils;
 import com.idlefish.flutterboost.containers.FlutterBoostActivity;
+
+import java.util.Map;
 
 public class MyFlutterBoostDelegate implements FlutterBoostDelegate {
 
@@ -25,5 +28,10 @@ public class MyFlutterBoostDelegate implements FlutterBoostDelegate {
                 .urlParams(options.arguments())
                 .build(FlutterBoost.instance().currentActivity());
         FlutterBoost.instance().currentActivity().startActivity(intent);
+    }
+
+    @Override
+    public Map<Object, Object> handleActivityResult(Intent intent) {
+        return FlutterBoostUtils.bundleToMap(intent.getExtras());
     }
 }


### PR DESCRIPTION
过滤非StandardMessageCodec可处理的数据，修复 Native 回传参数到 Flutter 时出现非基本类型数据编码异常 #1248