### PR TITLE
引擎预热，默认开启预热功能,目前已完成iOS端

### DIFF
--- a/ios/Classes/FlutterBoost.m
+++ b/ios/Classes/FlutterBoost.m
@@ -123,9 +123,9 @@
 - (void)warmUpEngine{
     FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:self.engine
                                                                       nibName:nil bundle:nil];
-    [vc beginAppearanceTransition:true animated:false];
+    [vc beginAppearanceTransition:YES animated:NO];
     [vc endAppearanceTransition];
-    [vc beginAppearanceTransition:false animated:false];
+    [vc beginAppearanceTransition:NO animated:NO];
     [vc endAppearanceTransition];
 }
 

--- a/ios/Classes/FlutterBoost.m
+++ b/ios/Classes/FlutterBoost.m
@@ -27,7 +27,6 @@
 #import "FlutterBoost.h"
 #import "FlutterBoostPlugin.h"
 #import "Options.h"
-
 @interface FlutterBoost ()
 
 @property (nonatomic, strong) FlutterEngine*  engine;
@@ -58,6 +57,11 @@
     void(^engineRun)(void) = ^(void) {
         
         [self.engine runWithEntrypoint:dartEntrypointFunctionName  initialRoute : initialRoute];
+        
+        //根据配置提前预热引擎,配置默认预热引擎
+        if(options.warmUpEngine){
+            [self warmUpEngine];
+        }
         
         Class clazz = NSClassFromString(@"GeneratedPluginRegistrant");
         SEL selector = NSSelectorFromString(@"registerWithRegistry:");
@@ -113,6 +117,16 @@
             engineDestroy();
         });
     }
+}
+
+///提前预热引擎
+- (void)warmUpEngine{
+    FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:self.engine
+                                                                      nibName:nil bundle:nil];
+    [vc beginAppearanceTransition:true animated:false];
+    [vc endAppearanceTransition];
+    [vc beginAppearanceTransition:false animated:false];
+    [vc endAppearanceTransition];
 }
 
 + (instancetype)instance{

--- a/ios/Classes/Options.h
+++ b/ios/Classes/Options.h
@@ -40,7 +40,7 @@
 @property (nonatomic, strong) FlutterDartProject* dartObject;
 
 ///是否提前预热引擎，如果提前预热引擎，可以减少第一次打开flutter页面的短暂白屏，以及字体大小跳动的现象
-///默认值为true
+///默认值为YES
 @property (nonatomic, assign) BOOL warmUpEngine;
 
 ///创建一个默认的Options对象

--- a/ios/Classes/Options.h
+++ b/ios/Classes/Options.h
@@ -39,6 +39,10 @@
 ///FlutterDartProject数据
 @property (nonatomic, strong) FlutterDartProject* dartObject;
 
+///是否提前预热引擎，如果提前预热引擎，可以减少第一次打开flutter页面的短暂白屏，以及字体大小跳动的现象
+///默认值为true
+@property (nonatomic, assign) BOOL warmUpEngine;
+
 ///创建一个默认的Options对象
 + (FlutterBoostSetupOptions*)createDefault;
 

--- a/ios/Classes/Options.m
+++ b/ios/Classes/Options.m
@@ -33,7 +33,7 @@
     if (self) {
         self.dartEntryPoint = @"main";
         self.initalRoute = @"/";
-        self.warmUpEngine = true;
+        self.warmUpEngine = YES;
     }
     return self;
 }

--- a/ios/Classes/Options.m
+++ b/ios/Classes/Options.m
@@ -33,6 +33,7 @@
     if (self) {
         self.dartEntryPoint = @"main";
         self.initalRoute = @"/";
+        self.warmUpEngine = true;
     }
     return self;
 }


### PR DESCRIPTION
关联issue：
#1272 
#1243 

在没有开启引擎预热的情况，大多数情况第一次打开flutter页面会出现短暂的白屏/黑屏，以及字体大小跳动的情况，这里在启动的时候扔一个空的FlutterVC让engine去画一下，达到引擎预渲染的目的，整个逻辑比较简单，也不需要修改任何dart侧的逻辑，只需要在boost初始化启动的时候根据参数判断是否需要预热，目前只做了ios端。

预热效果前后对比（模式为release，工程为example_new）

关闭引擎预热
https://user-images.githubusercontent.com/49340347/132168968-1d0441c2-6504-48a6-8332-8c2cdaa5f4b2.mp4
开启预热
https://user-images.githubusercontent.com/49340347/132168884-49442e1b-a0ba-4c89-a6c3-881ec81b9760.mp4