### PR TITLE
根据容器内部的侧滑手势的事件发送key的优化，避免多个vc同时接收到事件

### DIFF
--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -213,7 +213,6 @@ _Pragma("clang diagnostic pop")
     // 注册侧滑手势改变的监听，当容器内部的page大于1的时候，将不允许原生容器的侧滑手势
     // 当内部Page等于1的时候，会允许原生容器的侧滑
     self.removePopGesEventCallback = [FlutterBoost.instance addEventListener:^(NSString *name, NSDictionary *arguments) {
-        NSLog(@"Debug::jinlai");
         @strongify(self)
         NSNumber *enablePopGesNum = arguments[@"enablePopGes"];
         BOOL enable = [enablePopGesNum boolValue];

--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -213,11 +213,12 @@ _Pragma("clang diagnostic pop")
     // 注册侧滑手势改变的监听，当容器内部的page大于1的时候，将不允许原生容器的侧滑手势
     // 当内部Page等于1的时候，会允许原生容器的侧滑
     self.removePopGesEventCallback = [FlutterBoost.instance addEventListener:^(NSString *name, NSDictionary *arguments) {
+        NSLog(@"Debug::jinlai");
         @strongify(self)
         NSNumber *enablePopGesNum = arguments[@"enablePopGes"];
         BOOL enable = [enablePopGesNum boolValue];
         self.navigationController.interactivePopGestureRecognizer.enabled = enable;
-    } forName:@"disable_ios_pop_gesture_key"];
+    } forName:self.uniqueId];
     
 }
 

--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -75,7 +75,7 @@ _Pragma("clang diagnostic pop")
 @property (nonatomic, copy) NSString *flbNibName;
 @property (nonatomic, strong) NSBundle *flbNibBundle;
 @property(nonatomic, assign) BOOL opaque;
-@property (nonatomic, strong) FBVoidCallback removePopGesEventCallback;
+@property (nonatomic, strong) FBVoidCallback removeEventCallback;
 @end
 
 @implementation FBFlutterViewContainer
@@ -190,7 +190,7 @@ _Pragma("clang diagnostic pop")
 
 - (void)dealloc
 {
-    self.removePopGesEventCallback();
+    self.removeEventCallback();
     [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 
@@ -210,13 +210,20 @@ _Pragma("clang diagnostic pop")
     }
     
     @weakify(self)
-    // 注册侧滑手势改变的监听，当容器内部的page大于1的时候，将不允许原生容器的侧滑手势
-    // 当内部Page等于1的时候，会允许原生容器的侧滑
-    self.removePopGesEventCallback = [FlutterBoost.instance addEventListener:^(NSString *name, NSDictionary *arguments) {
+    // 为这个容器注册监听，监听内部的flutterPage往这个容器发的事件
+    self.removeEventCallback = [FlutterBoost.instance addEventListener:^(NSString *name, NSDictionary *arguments) {
         @strongify(self)
-        NSNumber *enablePopGesNum = arguments[@"enablePopGes"];
-        BOOL enable = [enablePopGesNum boolValue];
-        self.navigationController.interactivePopGestureRecognizer.enabled = enable;
+        //事件名
+        NSString *event = arguments[@"event"];
+        //事件参数
+        NSDictionary *args = arguments[@"args"];
+        
+        if ([event isEqualToString:@"enablePopGesture"]) {
+            // 多page情况下的侧滑动态禁用和启用事件
+            NSNumber *enableNum = args[@"enable"];
+            BOOL enable = [enableNum boolValue];
+            self.navigationController.interactivePopGestureRecognizer.enabled = enable;
+        }
     } forName:self.uniqueId];
     
 }

--- a/lib/boost_container.dart
+++ b/lib/boost_container.dart
@@ -13,8 +13,6 @@ class BoostContainer extends ChangeNotifier {
     _pages.add(BoostPage.create(pageInfo));
   }
 
-  static const String _disableIOSPopGestureKey = "disable_ios_pop_gesture_key";
-
   static BoostContainer of(BuildContext context) {
     final state = context.findAncestorStateOfType<BoostContainerState>();
     return state.container;
@@ -49,7 +47,7 @@ class BoostContainer extends ChangeNotifier {
     if (numPages() == 1) {
       /// disable the native slide pop gesture
       /// only iOS will receive this event ,Android will do nothing
-      BoostChannel.instance.sendEventToNative(_disableIOSPopGestureKey, {'enablePopGes': false});
+      BoostChannel.instance.sendEventToNative(pageInfo.uniqueId, {'enablePopGes': false});
     }
     if (page != null) {
       _pages.add(page);
@@ -64,7 +62,7 @@ class BoostContainer extends ChangeNotifier {
     if (numPages() == 2) {
       /// enable the native slide pop gesture
       /// only iOS will receive this event ,Android will do nothing
-      BoostChannel.instance.sendEventToNative(_disableIOSPopGestureKey, {'enablePopGes': true});
+      BoostChannel.instance.sendEventToNative(pageInfo.uniqueId, {'enablePopGes': true});
     }
     if (page != null) {
       _pages.remove(page);

--- a/lib/boost_container.dart
+++ b/lib/boost_container.dart
@@ -47,7 +47,10 @@ class BoostContainer extends ChangeNotifier {
     if (numPages() == 1) {
       /// disable the native slide pop gesture
       /// only iOS will receive this event ,Android will do nothing
-      BoostChannel.instance.sendEventToNative(pageInfo.uniqueId, {'enablePopGes': false});
+      BoostChannel.instance.sendEventToNative(pageInfo.uniqueId, {
+        'event': 'enablePopGesture',
+        "args": {'enable': false}
+      });
     }
     if (page != null) {
       _pages.add(page);
@@ -62,7 +65,10 @@ class BoostContainer extends ChangeNotifier {
     if (numPages() == 2) {
       /// enable the native slide pop gesture
       /// only iOS will receive this event ,Android will do nothing
-      BoostChannel.instance.sendEventToNative(pageInfo.uniqueId, {'enablePopGes': true});
+      BoostChannel.instance.sendEventToNative(pageInfo.uniqueId, {
+        'event': 'enablePopGesture',
+        "args": {'enable': true}
+      });
     }
     if (page != null) {
       _pages.remove(page);


### PR DESCRIPTION
之前是用统一的key来对单容器，多page的情况进行侧滑手势的监听控制，但是会带来一个问题，就是如果存在多个flutterBoostContainer，那么这些container都会接收到事件，这是不符合期望的，所以，修改后，只有当前page对应的那个vc才会接收到事件，形成对应关系