### PR TITLE
修复FlutterBoostApp中的containers集合和ContainerOverlay中数据不同步问题

### DIFF
--- a/example_new/ios/Runner/AppDelegate.swift
+++ b/example_new/ios/Runner/AppDelegate.swift
@@ -13,24 +13,29 @@ class AppDelegate:UIResponder, UIApplicationDelegate  {
         self.window = UIWindow(frame: UIScreen.main.bounds)
         self.window?.makeKeyAndVisible()
         
-        //主页
-        let homeViewController = HomeViewController()
-        homeViewController.tabBarItem = UITabBarItem(title: "首页", image: nil, tag: 0)
-    
-        
-        //flutter的tab 页
-        let hybridViewController = HybridViewController()
-        hybridViewController.tabBarItem = UITabBarItem(title: "flutter页", image: nil, tag: 1)
-        
-        
         //创建代理，做初始化操作
         let delegate = BoostDelegate()
-        FlutterBoost.instance().setup(application, delegate: delegate) { engine in
+        FlutterBoost.instance().setup(application, delegate: delegate, callback: { engine in
             
-        }
+        })
         
+        //下面开始做四个Tab页面，一个native，三个flutter
+        //native主页
+        let homeViewController = HomeViewController()
+        homeViewController.tabBarItem = UITabBarItem(title: "首页", image: nil, tag: 0)
+         
+        //下面是三个flutter vc
+        let fvc1  = FBFlutterViewContainer()!
+        fvc1.setName("tab1", uniqueId: nil, params: nil, opaque: true)
+        fvc1.tabBarItem = UITabBarItem(title: "flutter_tab1", image: nil, tag: 1)
+
+        let fvc2  = FBFlutterViewContainer()!
+        fvc2.setName("tab2", uniqueId: nil, params: nil, opaque: true)
+        fvc2.tabBarItem = UITabBarItem(title: "flutter_tab2", image: nil, tag: 2)
+
         let tabBarController = UITabBarController()
-        tabBarController.setViewControllers([homeViewController,hybridViewController], animated: false)
+        tabBarController.setViewControllers([homeViewController,fvc1,fvc2], animated: false)
+       
         let navigationViewController = UINavigationController(rootViewController: tabBarController)
         navigationViewController.navigationBar.isHidden = true
         self.window?.rootViewController = navigationViewController

--- a/example_new/lib/main.dart
+++ b/example_new/lib/main.dart
@@ -42,8 +42,8 @@ class _MyAppState extends State<MyApp> {
       return CupertinoPageRoute(
           settings: settings,
           builder: (_) {
-            Map<String, Object> map = settings.arguments;
-            String data = map['data'];
+            Map<String, Object> map = settings.arguments ?? {};
+            String data = map['data'] ?? '';
             return MainPage(
               data: data,
             );
@@ -52,7 +52,7 @@ class _MyAppState extends State<MyApp> {
 
     'simplePage': (settings, uniqueId) {
       Map<String, Object> map = settings.arguments ?? {};
-      String data = map['data'];
+      String data = map['data'] ?? '';
       return CupertinoPageRoute(
         settings: settings,
         builder: (_) => SimplePage(
@@ -60,7 +60,24 @@ class _MyAppState extends State<MyApp> {
         ),
       );
     },
-
+    'tab1': (settings, uniqueId) {
+      return CupertinoPageRoute(
+        settings: settings,
+        builder: (_) => TabPage(color: Colors.blue,title: 'Tab1',),
+      );
+    },
+    'tab2': (settings, uniqueId) {
+      return CupertinoPageRoute(
+        settings: settings,
+        builder: (_) => TabPage(color: Colors.red,title: 'Tab2',),
+      );
+    },
+    'tab3': (settings, uniqueId) {
+      return CupertinoPageRoute(
+        settings: settings,
+        builder: (_) => TabPage(color: Colors.orange,title: 'Tab3',),
+      );
+    },
     ///生命周期例子页面
     'lifecyclePage': (settings, uniqueId) {
       return CupertinoPageRoute(
@@ -102,7 +119,7 @@ class _MyAppState extends State<MyApp> {
   Widget appBuilder(Widget home) {
     return MaterialApp(
       home: home,
-      debugShowCheckedModeBanner: false,
+      debugShowCheckedModeBanner: true,
     );
   }
 
@@ -111,6 +128,21 @@ class _MyAppState extends State<MyApp> {
     return FlutterBoostApp(
       routeFactory,
       appBuilder: appBuilder,
+    );
+  }
+}
+
+
+class TabPage extends StatelessWidget {
+  final String title;
+  final Color color;
+  const TabPage({Key key, this.title, this.color}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor:color,
+      body: Center(child: Text(title ?? '',style:TextStyle(fontSize: 25)),),
     );
   }
 }

--- a/lib/container_overlay.dart
+++ b/lib/container_overlay.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
@@ -20,12 +22,14 @@ enum BoostSpecificEntryRefreshMode {
 }
 
 class ContainerOverlayEntry extends OverlayEntry {
-  ContainerOverlayEntry(BoostContainer container)
-      : containerUniqueId = container.pageInfo.uniqueId,
-        super(builder: (ctx) => BoostContainerWidget(container: container), opaque: true, maintainState: true);
+  ///This container for this [ContainerOverlayEntry]
+  final BoostContainer container;
+
+  ContainerOverlayEntry(this.container)
+      : super(builder: (ctx) => BoostContainerWidget(container: container), opaque: true, maintainState: true);
 
   /// This overlay's id, which is the same as the it's related container
-  final String containerUniqueId;
+  String get containerUniqueId => container.pageInfo.uniqueId;
 
   @override
   String toString() {
@@ -41,7 +45,24 @@ class ContainerOverlay {
 
   static final ContainerOverlay instance = ContainerOverlay._();
 
+  /// All of the container entries in flutter boost app
   final List<ContainerOverlayEntry> _lastEntries = <ContainerOverlayEntry>[];
+
+  /// get top container in this [ContainerOverlay],if [_lastEntries] is empty,return null
+  /// else will return the last container
+  BoostContainer get topContainer {
+    if (_lastEntries.isEmpty) {
+      return null;
+    }
+    return _lastEntries.last.container;
+  }
+
+  /// Containers in [ContainerOverlay] it is unmodifiable
+  /// we can only modify containers
+  /// using refresh method using [ContainerOverlay.refreshSpecificOverlayEntries]
+  UnmodifiableListView<BoostContainer> get containers => UnmodifiableListView(_lastEntries.map((entry) {
+        return entry.container;
+  }).toList(growable: false));
 
   static ContainerOverlayEntryFactory _overlayEntryFactory;
 

--- a/lib/container_overlay.dart
+++ b/lib/container_overlay.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
@@ -22,14 +20,12 @@ enum BoostSpecificEntryRefreshMode {
 }
 
 class ContainerOverlayEntry extends OverlayEntry {
-  ///This container for this [ContainerOverlayEntry]
-  final BoostContainer container;
-
-  ContainerOverlayEntry(this.container)
-      : super(builder: (ctx) => BoostContainerWidget(container: container), opaque: true, maintainState: true);
+  ContainerOverlayEntry(BoostContainer container)
+      : containerUniqueId = container.pageInfo.uniqueId,
+        super(builder: (ctx) => BoostContainerWidget(container: container), opaque: true, maintainState: true);
 
   /// This overlay's id, which is the same as the it's related container
-  String get containerUniqueId => container.pageInfo.uniqueId;
+  final String containerUniqueId;
 
   @override
   String toString() {
@@ -45,24 +41,7 @@ class ContainerOverlay {
 
   static final ContainerOverlay instance = ContainerOverlay._();
 
-  /// All of the container entries in flutter boost app
   final List<ContainerOverlayEntry> _lastEntries = <ContainerOverlayEntry>[];
-
-  /// get top container in this [ContainerOverlay],if [_lastEntries] is empty,return null
-  /// else will return the last container
-  BoostContainer get topContainer {
-    if (_lastEntries.isEmpty) {
-      return null;
-    }
-    return _lastEntries.last.container;
-  }
-
-  /// Containers in [ContainerOverlay] it is unmodifiable
-  /// we can only modify containers
-  /// using refresh method using [ContainerOverlay.refreshSpecificOverlayEntries]
-  UnmodifiableListView<BoostContainer> get containers => UnmodifiableListView(_lastEntries.map((entry) {
-        return entry.container;
-  }).toList(growable: false));
 
   static ContainerOverlayEntryFactory _overlayEntryFactory;
 

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -52,13 +53,11 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
   final Map<String, Completer<Object>> _pendingResult =
       <String, Completer<Object>>{};
 
-  List<BoostContainer> get containers => _containers;
-  final List<BoostContainer> _containers = <BoostContainer>[];
+  UnmodifiableListView<BoostContainer> get containers => ContainerOverlay.instance.containers;
+  BoostContainer get topContainer => ContainerOverlay.instance.topContainer;
 
   /// All interceptors from widget
   List<BoostInterceptor> get interceptors => widget.interceptors;
-
-  BoostContainer get topContainer => containers.last;
 
   NativeRouterApi get nativeRouterApi => _nativeRouterApi;
   NativeRouterApi _nativeRouterApi;
@@ -76,15 +75,11 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
 
   @override
   void initState() {
-    assert(
-        BoostFlutterBinding.instance != null,
-        'BoostFlutterBinding is not initialized，'
-        'please refer to "class CustomFlutterBinding" in example project');
+    // assert(
+    //     BoostFlutterBinding.instance != null,
+    //     'BoostFlutterBinding is not initialized，'
+    //     'please refer to "class CustomFlutterBinding" in example project');
 
-    /// create the container matching the initial route
-    final BoostContainer initialContainer =
-        _createContainer(PageInfo(pageName: widget.initialRoute));
-    _containers.add(initialContainer);
     _nativeRouterApi = NativeRouterApi();
     _boostFlutterRouterApi = BoostFlutterRouterApi(this);
     super.initState();
@@ -94,6 +89,9 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     // overlayKey.currentState to load complete....
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // add this container in route
+      /// create the container matching the initial route
+      final BoostContainer initialContainer =
+      _createContainer(PageInfo(pageName: widget.initialRoute));
       refreshOnPush(initialContainer);
       _addAppLifecycleStateEventListener();
     });
@@ -266,9 +264,6 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     final existed = _findContainerByUniqueId(uniqueId);
     if (existed != null) {
       if (topContainer?.pageInfo?.uniqueId != uniqueId) {
-        containers.remove(existed);
-        containers.add(existed);
-
         //move the overlayEntry which matches this existing container to the top
         refreshOnMoveToTop(existed);
       }
@@ -280,7 +275,6 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
           withContainer: true);
       final container = _createContainer(pageInfo);
       final previousContainer = topContainer;
-      containers.add(container);
       BoostLifecycleBinding.instance
           .containerDidPush(container, previousContainer);
 
@@ -458,7 +452,6 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
 
     final container = _findContainerByUniqueId(uniqueId);
     if (container != null) {
-      containers.remove(container);
       BoostLifecycleBinding.instance.containerDidPop(container, topContainer);
 
       //remove the overlayEntry matching this container

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -75,10 +75,10 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
 
   @override
   void initState() {
-    // assert(
-    //     BoostFlutterBinding.instance != null,
-    //     'BoostFlutterBinding is not initialized，'
-    //     'please refer to "class CustomFlutterBinding" in example project');
+    assert(
+        BoostFlutterBinding.instance != null,
+        'BoostFlutterBinding is not initialized，'
+        'please refer to "class CustomFlutterBinding" in example project');
 
     _nativeRouterApi = NativeRouterApi();
     _boostFlutterRouterApi = BoostFlutterRouterApi(this);
@@ -277,8 +277,10 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
       final previousContainer = topContainer;
       BoostLifecycleBinding.instance
           .containerDidPush(container, previousContainer);
-
       // Add a new overlay entry with this container
+
+
+
       refreshOnPush(container);
     }
     Logger.log('pushContainer, uniqueId=$uniqueId, existed=$existed,'

--- a/lib/flutter_boost_app.dart
+++ b/lib/flutter_boost_app.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -53,11 +52,13 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
   final Map<String, Completer<Object>> _pendingResult =
       <String, Completer<Object>>{};
 
-  UnmodifiableListView<BoostContainer> get containers => ContainerOverlay.instance.containers;
-  BoostContainer get topContainer => ContainerOverlay.instance.topContainer;
+  List<BoostContainer> get containers => _containers;
+  final List<BoostContainer> _containers = <BoostContainer>[];
 
   /// All interceptors from widget
   List<BoostInterceptor> get interceptors => widget.interceptors;
+
+  BoostContainer get topContainer => containers.last;
 
   NativeRouterApi get nativeRouterApi => _nativeRouterApi;
   NativeRouterApi _nativeRouterApi;
@@ -80,6 +81,13 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
         'BoostFlutterBinding is not initialized，'
         'please refer to "class CustomFlutterBinding" in example project');
 
+<<<<<<< HEAD
+=======
+    /// create the container matching the initial route
+    final BoostContainer initialContainer =
+        _createContainer(PageInfo(pageName: widget.initialRoute));
+    _containers.add(initialContainer);
+>>>>>>> parent of d1afad3 (修复FlutterBoostApp中的containers和ContainerOverlay中container的数据不同步问题)
     _nativeRouterApi = NativeRouterApi();
     _boostFlutterRouterApi = BoostFlutterRouterApi(this);
     super.initState();
@@ -89,9 +97,6 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     // overlayKey.currentState to load complete....
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // add this container in route
-      /// create the container matching the initial route
-      final BoostContainer initialContainer =
-      _createContainer(PageInfo(pageName: widget.initialRoute));
       refreshOnPush(initialContainer);
       _addAppLifecycleStateEventListener();
     });
@@ -264,6 +269,9 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     final existed = _findContainerByUniqueId(uniqueId);
     if (existed != null) {
       if (topContainer?.pageInfo?.uniqueId != uniqueId) {
+        containers.remove(existed);
+        containers.add(existed);
+
         //move the overlayEntry which matches this existing container to the top
         refreshOnMoveToTop(existed);
       }
@@ -275,6 +283,7 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
           withContainer: true);
       final container = _createContainer(pageInfo);
       final previousContainer = topContainer;
+      containers.add(container);
       BoostLifecycleBinding.instance
           .containerDidPush(container, previousContainer);
       // Add a new overlay entry with this container
@@ -454,6 +463,7 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
 
     final container = _findContainerByUniqueId(uniqueId);
     if (container != null) {
+      containers.remove(container);
       BoostLifecycleBinding.instance.containerDidPop(container, topContainer);
 
       //remove the overlayEntry matching this container


### PR DESCRIPTION
关联issue:
#1358 

问题描述可以看issue内部的说明，这里说明一下问题原因
因为在初始化的时候就初始化了tab页面，而flutter内部的初始化路由（也就是initalRoute是之后放入的），这时候会导致`FlutterBoostApp`中的containers数据和`ContainerOverlay`中的数据不同步，顺序不对，导致第一次切换到最后一个tab的时候，`FlutterBoostApp`误以为tab页面在最上面，进而没有最moveToTop操作，就会展现出白屏，**这里的白屏，实际上就是初始化路由页面，可以把初始化路由页面的背景改成红色可以验证这个事实。**

**问题解决思路：**
之前，`FlutterBoostApp`中有一个`List<BoostContainer>`的集合，但是，`ContainerOverlay`也有一个entry的集合，实际上，这两个集合是应该一一对应的，而不是维护两份数据，所以这里，统一将`FlutterBoostApp`收口到`ContainerOverlay`中进行返回，所有的container的刷新方法也通过`ContainerOverlay`中的`refreshSpecificOverlayEntries`进行刷新，外界不能够直接对`container`进行操作,这样就可以避免上述问题
