### PR TITLE
增加tab模式的example，删除iOS端无用的生命周期，避免初始化阶段进行push，造成初始化情况下tab白屏问题

### DIFF
--- a/example_new/ios/Runner/AppDelegate.swift
+++ b/example_new/ios/Runner/AppDelegate.swift
@@ -13,24 +13,29 @@ class AppDelegate:UIResponder, UIApplicationDelegate  {
         self.window = UIWindow(frame: UIScreen.main.bounds)
         self.window?.makeKeyAndVisible()
         
-        //主页
-        let homeViewController = HomeViewController()
-        homeViewController.tabBarItem = UITabBarItem(title: "首页", image: nil, tag: 0)
-    
-        
-        //flutter的tab 页
-        let hybridViewController = HybridViewController()
-        hybridViewController.tabBarItem = UITabBarItem(title: "flutter页", image: nil, tag: 1)
-        
-        
         //创建代理，做初始化操作
         let delegate = BoostDelegate()
-        FlutterBoost.instance().setup(application, delegate: delegate) { engine in
+        FlutterBoost.instance().setup(application, delegate: delegate, callback: { engine in
             
-        }
+        })
         
+        //下面开始做四个Tab页面，一个native，三个flutter
+        //native主页
+        let homeViewController = HomeViewController()
+        homeViewController.tabBarItem = UITabBarItem(title: "首页", image: nil, tag: 0)
+         
+        //下面是三个flutter vc
+        let fvc1  = FBFlutterViewContainer()!
+        fvc1.setName("tab1", uniqueId: nil, params: nil, opaque: true)
+        fvc1.tabBarItem = UITabBarItem(title: "flutter_tab1", image: nil, tag: 1)
+
+        let fvc2  = FBFlutterViewContainer()!
+        fvc2.setName("tab2", uniqueId: nil, params: nil, opaque: true)
+        fvc2.tabBarItem = UITabBarItem(title: "flutter_tab2", image: nil, tag: 2)
+
         let tabBarController = UITabBarController()
-        tabBarController.setViewControllers([homeViewController,hybridViewController], animated: false)
+        tabBarController.setViewControllers([homeViewController,fvc1,fvc2], animated: false)
+       
         let navigationViewController = UINavigationController(rootViewController: tabBarController)
         navigationViewController.navigationBar.isHidden = true
         self.window?.rootViewController = navigationViewController

--- a/example_new/lib/main.dart
+++ b/example_new/lib/main.dart
@@ -42,8 +42,8 @@ class _MyAppState extends State<MyApp> {
       return CupertinoPageRoute(
           settings: settings,
           builder: (_) {
-            Map<String, Object> map = settings.arguments;
-            String data = map['data'];
+            Map<String, Object> map = settings.arguments ?? {};
+            String data = map['data'] ?? '';
             return MainPage(
               data: data,
             );
@@ -52,7 +52,7 @@ class _MyAppState extends State<MyApp> {
 
     'simplePage': (settings, uniqueId) {
       Map<String, Object> map = settings.arguments ?? {};
-      String data = map['data'];
+      String data = map['data'] ?? '';
       return CupertinoPageRoute(
         settings: settings,
         builder: (_) => SimplePage(
@@ -60,7 +60,24 @@ class _MyAppState extends State<MyApp> {
         ),
       );
     },
-
+    'tab1': (settings, uniqueId) {
+      return CupertinoPageRoute(
+        settings: settings,
+        builder: (_) => TabPage(color: Colors.blue,title: 'Tab1',),
+      );
+    },
+    'tab2': (settings, uniqueId) {
+      return CupertinoPageRoute(
+        settings: settings,
+        builder: (_) => TabPage(color: Colors.red,title: 'Tab2',),
+      );
+    },
+    'tab3': (settings, uniqueId) {
+      return CupertinoPageRoute(
+        settings: settings,
+        builder: (_) => TabPage(color: Colors.orange,title: 'Tab3',),
+      );
+    },
     ///生命周期例子页面
     'lifecyclePage': (settings, uniqueId) {
       return CupertinoPageRoute(
@@ -102,7 +119,7 @@ class _MyAppState extends State<MyApp> {
   Widget appBuilder(Widget home) {
     return MaterialApp(
       home: home,
-      debugShowCheckedModeBanner: false,
+      debugShowCheckedModeBanner: true,
     );
   }
 
@@ -111,6 +128,21 @@ class _MyAppState extends State<MyApp> {
     return FlutterBoostApp(
       routeFactory,
       appBuilder: appBuilder,
+    );
+  }
+}
+
+
+class TabPage extends StatelessWidget {
+  final String title;
+  final Color color;
+  const TabPage({Key key, this.title, this.color}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor:color,
+      body: Center(child: Text(title ?? '',style:TextStyle(fontSize: 25)),),
     );
   }
 }

--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -152,21 +152,6 @@ _Pragma("clang diagnostic pop")
     self.uniqueId = [[NSUUID UUID] UUIDString];
 }
 
-- (void)willMoveToParentViewController:(UIViewController *)parent {
-    if (parent && _name) {
-        //当VC将要被移动到Parent中的时候，才出发flutter层面的page init
-        FBCommonParams* params = [[FBCommonParams alloc] init];
-        params.pageName = _name;
-        params.arguments = _params;
-        params.uniqueId = self.uniqueId;
-        params.opaque = [[NSNumber alloc]initWithBool:self.opaque];
-        
-        [FB_PLUGIN.flutterApi pushRoute: params completion:^(NSError * e) {
-        }];
-    }
-    [super willMoveToParentViewController:parent];
-}
-
 - (void)didMoveToParentViewController:(UIViewController *)parent {
     if (!parent) {
         //当VC被移出parent时，就通知flutter层销毁page


### PR DESCRIPTION
关联issue：
https://github.com/alibaba/flutter_boost/issues/1358


在有flutter tab的情况下，如果willMoveToParentViewController进行调用，那么初始化的内部数据会有不同步问题，造成点击最后一个tab会出现白屏（初始化路由页面）的问题。

目前willMoveToParentViewController会造成一个页面显示的时候两次push，比较冗余