### PR TITLE
将控制iOS手势的方法收口到BoostChannel作为通用方法，以及在container的show的监听中做手势的动态禁用和启用

### DIFF
--- a/example_new/ios/Runner/Controllers/HomeViewController.swift
+++ b/example_new/ios/Runner/Controllers/HomeViewController.swift
@@ -36,6 +36,13 @@ class HomeViewController: UIViewController {
         FlutterBoost.instance().open(options)
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        //如果你想要native的controller拥有侧滑返回，那么做好加上这句
+        //因为内部Boost可能会处理你的导航器侧滑手势
+        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = true
+    }
+    
     ///例子：present flutter 透明dialog页面
     @objc func onTapPresentDialogButton(){
 

--- a/example_new/lib/pages/main_page.dart
+++ b/example_new/lib/pages/main_page.dart
@@ -84,7 +84,14 @@ class _MainPageState extends State<MainPage> {
         Map<String, Object> result = {'data': _controller.text};
         BoostNavigator.instance.pop(result);
       }),
-      Model("open flutter page", () {
+      Model("open flutter main page", () {
+        BoostNavigator.instance.push("mainPage",
+            withContainer: withContainer.value,
+            arguments: {
+              'data': _controller.text
+            }).then((value) => showTipIfNeeded(value.toString()));
+      }),
+      Model("open flutter simple page", () {
         BoostNavigator.instance.push("simplePage",
             withContainer: withContainer.value,
             arguments: {

--- a/lib/boost_channel.dart
+++ b/lib/boost_channel.dart
@@ -44,4 +44,21 @@ class BoostChannel {
       ..arguments = args;
     _appState.nativeRouterApi.sendEventToNative(params);
   }
+
+  /// enable iOS native pop gesture for container matching [containerId]
+  void enablePopGesture({@required String containerId}){
+    assert(containerId != null && containerId.isNotEmpty);
+    BoostChannel.instance.sendEventToNative(containerId, {
+      'event': 'enablePopGesture',
+      "args": {'enable': true}
+    });
+  }
+  /// disable iOS native pop gesture for container matching [containerId]
+  void disablePopGesture({@required String containerId}){
+    assert(containerId != null && containerId.isNotEmpty);
+    BoostChannel.instance.sendEventToNative(containerId, {
+      'event': 'enablePopGesture',
+      "args": {'enable': false}
+    });
+  }
 }

--- a/lib/boost_container.dart
+++ b/lib/boost_container.dart
@@ -48,10 +48,7 @@ class BoostContainer extends ChangeNotifier {
     if (numPages() == 1) {
       /// disable the native slide pop gesture
       /// only iOS will receive this event ,Android will do nothing
-      BoostChannel.instance.sendEventToNative(pageInfo.uniqueId, {
-        'event': 'enablePopGesture',
-        "args": {'enable': false}
-      });
+      BoostChannel.instance.disablePopGesture(containerId: pageInfo.uniqueId);
     }
     if (page != null) {
       _pages.add(page);
@@ -66,10 +63,7 @@ class BoostContainer extends ChangeNotifier {
     if (numPages() == 2) {
       /// enable the native slide pop gesture
       /// only iOS will receive this event ,Android will do nothing
-      BoostChannel.instance.sendEventToNative(pageInfo.uniqueId, {
-        'event': 'enablePopGesture',
-        "args": {'enable': true}
-      });
+      BoostChannel.instance.enablePopGesture(containerId: pageInfo.uniqueId);
     }
     if (page != null) {
       _pages.remove(page);

--- a/lib/boost_lifecycle_binding.dart
+++ b/lib/boost_lifecycle_binding.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 
+import 'boost_channel.dart';
 import 'boost_container.dart';
 import 'logger.dart';
 import 'page_visibility.dart';
@@ -86,6 +87,16 @@ class BoostLifecycleBinding {
   }
 
   void containerDidShow(BoostContainer container) {
+    assert(container != null);
+
+    ///When this container show,we check the nums of page in this container,
+    ///And change the pop gesture in this container
+    if(container.pages.length >= 2){
+      BoostChannel.instance.disablePopGesture(containerId: container.pageInfo.uniqueId);
+    }else{
+      BoostChannel.instance.enablePopGesture(containerId: container.pageInfo.uniqueId);
+    }
+
     Logger.log('boost_lifecycle: BoostLifecycleBinding.containerDidShow');
     if (_observerList != null && _observerList.isNotEmpty) {
       for (BoostLifecycleObserver observer in _observerList) {


### PR DESCRIPTION
在container之间跳转的时候，也同步动态手势的pop的配置
避免在flutter（不带container） -> flutter（不带container） -> flutter（带container） 的时候，最后一个container的手势侧滑失效，而在返回上一个container的时候，也会根据上一个container的内部flutter page数量，动态设置侧滑手势