### PR TITLE
[featurePR]: 修复android 6.0以下版本系统 TextureView 异常释放的问题;

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ JaminZhou <zhoujiamin1992@gmail.com>
 YunanChen <ync618@163.com>
 CheungSKei <180353389@qq.com>
 xujinping <804677682@qq.com>
+dengzq <956796570@qq.com>

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -17,8 +17,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import androidx.annotation.NonNull;
 import io.flutter.Log;
 import io.flutter.embedding.android.FlutterFragment;
+import io.flutter.embedding.android.FlutterTextureView;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.android.RenderMode;
 import io.flutter.embedding.android.TransparencyMode;
@@ -34,6 +36,7 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     private static final String TAG = "FlutterBoostFragment";
     private static final boolean DEBUG = false;
     private final String who = UUID.randomUUID().toString();
+    private final FlutterTextureHooker textureHooker=new FlutterTextureHooker();
     private FlutterView flutterView;
     private PlatformPlugin platformPlugin;
     private LifecycleStage stage;
@@ -68,6 +71,7 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     public void onDestroy() {
         super.onDestroy();
         stage = LifecycleStage.ON_DESTROY;
+        textureHooker.onFlutterTextureViewRelease();
         if (DEBUG) Log.d(TAG, "#onDestroy: " + this);
     }
 
@@ -217,6 +221,12 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     }
 
     @Override
+    public void onFlutterTextureViewCreated(@NonNull FlutterTextureView flutterTextureView) {
+        super.onFlutterTextureViewCreated(flutterTextureView);
+        textureHooker.hookFlutterTextureView(flutterTextureView);
+    }
+
+    @Override
     public Activity getContextActivity() {
         return getActivity();
     }
@@ -271,6 +281,7 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
 
         FlutterBoost.instance().getPlugin().onContainerAppeared(this);
         performAttach();
+        textureHooker.onFlutterTextureViewRestoreState();
         if (DEBUG) Log.d(TAG, "#didFragmentShow: " + this + ", isOpaque=" + isOpaque());
     }
 

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterTextureHooker.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterTextureHooker.java
@@ -1,0 +1,122 @@
+package com.idlefish.flutterboost.containers;
+
+import android.graphics.SurfaceTexture;
+import android.os.Build;
+import android.view.Surface;
+import android.view.TextureView;
+
+import com.idlefish.flutterboost.FlutterBoost;
+
+import java.lang.reflect.Field;
+
+import androidx.annotation.NonNull;
+import io.flutter.embedding.android.FlutterTextureView;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
+
+
+class FlutterTextureHooker {
+    private SurfaceTexture     restoreSurface;
+    private FlutterTextureView flutterTextureView;
+    private boolean            isNeedRestoreState = false;
+
+    /**
+     * Release surface when Activity.onDestroy / Fragment.onDestroy.
+     * Stop render when finish the last flutter boost container.
+     */
+    public void onFlutterTextureViewRelease() {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+            int containerSize = FlutterContainerManager.instance().getContainerSize();
+            if (containerSize == 1) {
+                FlutterEngine   engine   = FlutterBoost.instance().getEngine();
+                FlutterRenderer renderer = engine.getRenderer();
+                renderer.stopRenderingToSurface();
+            }
+            if (restoreSurface != null) {
+                restoreSurface.release();
+                restoreSurface = null;
+            }
+        }
+    }
+
+    /**
+     * Restore last surface for os version below Android.M.
+     * Call from Activity.onResume / Fragment.didFragmentShow.
+     */
+    public void onFlutterTextureViewRestoreState() {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+            if (restoreSurface != null && flutterTextureView != null && isNeedRestoreState) {
+                try {
+                    Class<? extends FlutterTextureView> aClass                         = flutterTextureView.getClass();
+                    Field                               isSurfaceAvailableForRendering = aClass.getDeclaredField("isSurfaceAvailableForRendering");
+                    isSurfaceAvailableForRendering.setAccessible(true);
+                    isSurfaceAvailableForRendering.set(flutterTextureView, true);
+
+                    Field isAttachedToFlutterRenderer = aClass.getDeclaredField("isAttachedToFlutterRenderer");
+                    isAttachedToFlutterRenderer.setAccessible(true);
+                    if (isAttachedToFlutterRenderer.getBoolean(flutterTextureView)) {
+                        FlutterEngine engine = FlutterBoost.instance().getEngine();
+                        if (engine != null) {
+
+                            FlutterRenderer flutterRenderer = engine.getRenderer();
+                            Surface         surface         = new Surface(restoreSurface);
+                            flutterRenderer.startRenderingToSurface(surface);
+
+                            flutterTextureView.setSurfaceTexture(restoreSurface);
+                        }
+                        restoreSurface = null;
+                        isNeedRestoreState = false;
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    /**
+     * Hook FlutterTextureView for os version below Android.M.
+     */
+    public void hookFlutterTextureView(@NonNull FlutterTextureView flutterTextureView) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+            TextureView.SurfaceTextureListener surfaceTextureListener = flutterTextureView.getSurfaceTextureListener();
+            this.flutterTextureView = flutterTextureView;
+            this.flutterTextureView.setSurfaceTextureListener(new TextureView.SurfaceTextureListener() {
+                @Override
+                public void onSurfaceTextureAvailable(SurfaceTexture surface, int width, int height) {
+                    surfaceTextureListener.onSurfaceTextureAvailable(surface, width, height);
+
+                }
+
+                @Override
+                public void onSurfaceTextureSizeChanged(SurfaceTexture surface, int width, int height) {
+                    surfaceTextureListener.onSurfaceTextureSizeChanged(surface, width, height);
+                }
+
+                @Override
+                public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
+                    try {
+                        Class<? extends FlutterTextureView> aClass                         = flutterTextureView.getClass();
+                        Field                               isSurfaceAvailableForRendering = aClass.getDeclaredField("isSurfaceAvailableForRendering");
+                        isSurfaceAvailableForRendering.setAccessible(true);
+                        isSurfaceAvailableForRendering.set(flutterTextureView, false);
+
+                        Field isAttachedToFlutterRenderer = aClass.getDeclaredField("isAttachedToFlutterRenderer");
+                        isAttachedToFlutterRenderer.setAccessible(true);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                    isNeedRestoreState = true;
+                    //return false, handle the last frame of surfaceTexture ourselves;
+                    return false;
+                }
+
+                @Override
+                public void onSurfaceTextureUpdated(SurfaceTexture surface) {
+                    surfaceTextureListener.onSurfaceTextureUpdated(surface);
+                    restoreSurface = surface;
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
修复描述：修复android 6.0以下版本系统 TextureView 异常释放的问题, 使 flutter_boost 能更好地支持 6.0以下系统版本;
解决方案:
针对6.0以下系统版本缓存最后一帧surface, 在 `Actvity.onResume` / `Fragment.didFragmentShow ` 恢复之前的状态。

关联issue: [#1380](https://github.com/alibaba/flutter_boost/issues/1380)