### PR TITLE
容器新增keepalive属性，避免内嵌页面提前释放缓存

### DIFF
--- a/example/ios/Runner/AppDelegate.m
+++ b/example/ios/Runner/AppDelegate.m
@@ -43,11 +43,13 @@
     
     UIViewControllerDemo *vc = [[UIViewControllerDemo alloc] initWithNibName:@"UIViewControllerDemo" bundle:[NSBundle mainBundle]];
     vc.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"hybrid" image:nil tag:0];
+        
    
     FBFlutterViewContainer *fvc = FBFlutterViewContainer.new ;
 
     [fvc setName:@"tab_friend" uniqueId:nil params:@{} opaque:YES];
     fvc.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"flutter_tab" image:nil tag:1];
+    fvc.keepAlive = true;
 
 
     UITabBarController *tabVC = [[UITabBarController alloc] init];

--- a/example/lib/tab/simple_widget.dart
+++ b/example/lib/tab/simple_widget.dart
@@ -70,6 +70,14 @@ class _SimpleWidgetState extends State<SimpleWidget>
               child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
+              FadeInImage.assetNetwork(
+                placeholder: "images/flutter.png",
+                image: "https://gw.alicdn.com/tfs/TB1aUlEYLb2gK0jSZK9XXaEgFXa-252-252.png",
+                width: 300,
+                height: 300,
+                fadeOutDuration: const Duration(milliseconds: 300),
+                fadeInDuration: const Duration(milliseconds: 700),
+              ),
               Container(
                 margin: const EdgeInsets.only(top: 80.0),
                 child: Text(

--- a/ios/Classes/FlutterBoostPlugin.h
+++ b/ios/Classes/FlutterBoostPlugin.h
@@ -31,6 +31,8 @@
 typedef void (^FBEventListener) (NSString *name ,
                                  NSDictionary *arguments);
 typedef void (^FBVoidCallback)(void);
+typedef void (^FBContainersEnumeration)(id key, id<FBFlutterContainer> obj, BOOL *stop);
+
 
 @interface FlutterBoostPlugin : NSObject <FlutterPlugin>
 @property (nonatomic, strong) id<FlutterBoostDelegate> delegate;
@@ -41,6 +43,7 @@ typedef void (^FBVoidCallback)(void);
 - (void)containerAppeared:(id<FBFlutterContainer>)container;
 - (void)containerDisappeared:(id<FBFlutterContainer>)container;
 - (void)containerDestroyed:(id<FBFlutterContainer>)container;
+- (void)enumerateContainers:(FBContainersEnumeration)enumeration;
 
 - (FBVoidCallback)addEventListener:(FBEventListener)listener forName:(NSString *)key;
 + (FlutterBoostPlugin* )getPlugin:(FlutterEngine*)engine ;

--- a/ios/Classes/FlutterBoostPlugin.m
+++ b/ios/Classes/FlutterBoostPlugin.m
@@ -88,6 +88,11 @@
     }
 }
 
+- (void)enumerateContainers:(FBContainersEnumeration)enumeration{
+    [self.containerManager enumerateContainers:enumeration];
+}
+
+
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>  *)registrar {
     FlutterBoostPlugin* plugin = [[FlutterBoostPlugin alloc] initWithMessenger:(registrar.messenger)];
     [registrar publish:plugin];

--- a/ios/Classes/container/FBFlutterContainer.h
+++ b/ios/Classes/container/FBFlutterContainer.h
@@ -29,5 +29,6 @@
 - (NSString *)uniqueId;
 - (NSString *)uniqueIDString;
 - (BOOL)opaque;
+- (BOOL)keepAlive;
 - (void)setName:(NSString *)name uniqueId:(NSString *)uniqueId params:(NSDictionary *)params opaque:(BOOL) opaque;
 @end

--- a/ios/Classes/container/FBFlutterContainerManager.h
+++ b/ios/Classes/container/FBFlutterContainerManager.h
@@ -25,6 +25,8 @@
 #import <Foundation/Foundation.h>
 #import "FBFlutterContainer.h"
 
+typedef void (^FBContainersEnumeration)(id key, id<FBFlutterContainer> obj, BOOL *stop);
+
 @interface FBFlutterContainerManager : NSObject
 
 - (void)addContainer:(id<FBFlutterContainer>)container forUniqueId:(NSString *)uniqueId;
@@ -40,6 +42,8 @@
 - (BOOL)isTopContainer:(NSString *)uniqueId;
 
 - (NSInteger)containerSize;
+
+- (void)enumerateContainers:(FBContainersEnumeration)enumeration;
 
 
 @end

--- a/ios/Classes/container/FBFlutterContainerManager.m
+++ b/ios/Classes/container/FBFlutterContainerManager.m
@@ -87,5 +87,9 @@
     return self.allContainers.count;
 }
 
+-(void)enumerateContainers:(FBContainersEnumeration)enumeration{
+    [self.allContainers enumerateKeysAndObjectsUsingBlock:enumeration];
+}
+
 @end
 

--- a/ios/Classes/container/FBFlutterViewContainer.h
+++ b/ios/Classes/container/FBFlutterViewContainer.h
@@ -29,6 +29,7 @@
 @interface FBFlutterViewContainer : FlutterViewController<FBFlutterContainer>
 @property (nonatomic,copy,readwrite) NSString *name;
 @property (nonatomic, strong) NSNumber *disablePopGesture;
+@property (nonatomic, assign) BOOL keepAlive; 
 - (instancetype)init;
 - (void)surfaceUpdated:(BOOL)appeared;
 - (void)updateViewportMetrics;

--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -24,6 +24,7 @@
 
 #import <Foundation/Foundation.h>
 #import "FBFlutterViewContainer.h"
+#import "FBFlutterContainerManager.h"
 #import "FlutterBoost.h"
 #import "FBLifecycle.h"
 #import <objc/message.h>
@@ -241,7 +242,16 @@ _Pragma("clang diagnostic pop")
         //detail:https://github.com/flutter/engine/blob/07e2520d5d8f837da439317adab4ecd7bff2f72d/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm#L529
         [self surfaceUpdated:NO];
         
-        if(ENGINE.viewController != nil) {
+        __block BOOL release = true;
+        [FB_PLUGIN enumerateContainers:^(id key, id<FBFlutterContainer> obj, BOOL *stop) {
+            //排除自己并且keepalive属性为true
+            //set nil to engine's controller only has no container or container is not keepalive
+            if(obj != self && obj.keepAlive){
+                release = false;
+            }
+        }];
+        
+        if(ENGINE.viewController != nil && release) {
             ENGINE.viewController = nil;
         }
     }


### PR DESCRIPTION
iOS容器新增keepalive属性，避免内嵌页面(例如tab)切换过程中提前释放缓存