### PR TITLE
[Flutter] 修改container里面 addPage 实现方式。解决两个问题：

### DIFF
--- a/lib/boost_container.dart
+++ b/lib/boost_container.dart
@@ -52,7 +52,7 @@ class BoostContainer extends ChangeNotifier {
     }
     if (page != null) {
       _pages.add(page);
-      notifyListeners();
+      navigator.push(page.route);
       return page.popped;
     }
     return null;
@@ -68,7 +68,6 @@ class BoostContainer extends ChangeNotifier {
     if (page != null) {
       _pages.remove(page);
       page.didComplete(result);
-      notifyListeners();
     }
   }
 
@@ -119,22 +118,7 @@ class BoostContainerState extends State<BoostContainerWidget> {
   @override
   void initState() {
     assert(container != null);
-    container.addListener(refreshContainer);
     super.initState();
-  }
-
-  @override
-  void didUpdateWidget(covariant BoostContainerWidget oldWidget) {
-    if (oldWidget != widget) {
-      oldWidget.container.removeListener(refreshContainer);
-      container.addListener(refreshContainer);
-    }
-    super.didUpdateWidget(oldWidget);
-  }
-
-  ///just refresh
-  void refreshContainer() {
-    setState(() {});
   }
 
   @override
@@ -160,7 +144,6 @@ class BoostContainerState extends State<BoostContainerWidget> {
 
   @override
   void dispose() {
-    container.removeListener(refreshContainer);
     super.dispose();
   }
 }


### PR DESCRIPTION
1.Flutter A页面 使用 withContainer=false 方式打开 Flutter B页面时，Flutter A页面会 rebuild；
2.Flutter B页面返回 Flutter A页面时，A，B页面都会 rebuild。