### PR TITLE
[Android] 修复 Android Q 机型透明模式下打开第二个Flutter页面失败的bug。

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -89,9 +89,12 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
     @Override
     public void onResume() {
         super.onResume();
-        FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
+        FlutterViewContainer top;
+        final FlutterContainerManager containerManager = FlutterContainerManager.instance();
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
-            if (top != null && top != this && !top.isOpaque() && top.isPausing()) {
+            top = containerManager.getTopActivityContainer();
+            boolean isActiveContainer = containerManager.isActiveContainer(this);
+            if (isActiveContainer && top != null && top != this && !top.isOpaque() && top.isPausing()) {
                 Log.w(TAG, "Skip the unexpected activity lifecycle event on Android Q. " +
                         "See https://issuetracker.google.com/issues/185693011 for more details.");
                 return;
@@ -101,6 +104,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
         stage = LifecycleStage.ON_RESUME;
 
         // try to detach prevous container from the engine.
+        top = containerManager.getTopContainer();
         if (top != null && top != this) top.detachFromEngineIfNeeded();
 
         performAttach();
@@ -112,7 +116,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
     @Override
     protected void onPause() {
         super.onPause();
-        FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
+        FlutterViewContainer top = FlutterContainerManager.instance().getTopActivityContainer();
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
             if (top != null && top != this && !top.isOpaque() && top.isPausing()) {
                 Log.w(TAG, "Skip the unexpected activity lifecycle event on Android Q. " +

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -118,8 +118,10 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     public void onResume() {
         super.onResume();
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
-            FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
-            if (top != null && top != this && !top.isOpaque() && top.isPausing()) {
+            final FlutterContainerManager containerManager = FlutterContainerManager.instance();
+            FlutterViewContainer top = containerManager.getTopActivityContainer();
+            boolean isActiveContainer = containerManager.isActiveContainer(this);
+            if (isActiveContainer && top != null && top != this.getContextActivity() && !top.isOpaque() && top.isPausing()) {
                 Log.w(TAG, "Skip the unexpected activity lifecycle event on Android Q. " +
                         "See https://issuetracker.google.com/issues/185693011 for more details.");
                 return;
@@ -144,8 +146,8 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     public void onPause() {
         super.onPause();
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
-            FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
-            if (top != null && top != this && !top.isOpaque() && top.isPausing()) {
+            FlutterViewContainer top = FlutterContainerManager.instance().getTopActivityContainer();
+            if (top != null && top != this.getContextActivity() && !top.isOpaque() && top.isPausing()) {
                 Log.w(TAG, "Skip the unexpected activity lifecycle event on Android Q. " +
                         "See https://issuetracker.google.com/issues/185693011 for more details.");
                 return;

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterContainerManager.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterContainerManager.java
@@ -1,5 +1,7 @@
 package com.idlefish.flutterboost.containers;
 
+import android.app.Activity;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -58,9 +60,27 @@ public class FlutterContainerManager {
         return null;
     }
 
+    public boolean isActiveContainer(FlutterViewContainer container) {
+        return activeContainers.contains(container);
+    }
+
     public FlutterViewContainer getTopContainer() {
         if (activeContainers.size() > 0) {
             return activeContainers.getLast();
+        }
+        return null;
+    }
+
+    public FlutterViewContainer getTopActivityContainer() {
+        final int size = activeContainers.size();
+        if (size == 0) {
+            return null;
+        }
+        for (int i = size - 1; i >= 0; i--) {
+            final FlutterViewContainer container = activeContainers.get(i);
+            if (container instanceof Activity) {
+                return container;
+            }
         }
         return null;
     }


### PR DESCRIPTION
问题详情见 https://github.com/alibaba/flutter_boost/issues/1295，      由于Android Q系统bug，如无必要，慎用透明Activity。
