### PR TITLE
[iOS] 修复应用置后台后，通过外链接起应用进入Flutter页面,applicationState还处于inActive状态，无法发送…

### DIFF
--- a/ios/Classes/container/FBLifecycle.m
+++ b/ios/Classes/container/FBLifecycle.m
@@ -37,9 +37,7 @@
     }
 }
 + (void)resume{
-    if([UIApplication sharedApplication].applicationState == UIApplicationStateActive){
-        [[FlutterBoost instance]sendEventToFlutterWith:@"app_lifecycle_changed_key" arguments:@{@"lifecycleState":@0}];
-    }
+    [[FlutterBoost instance]sendEventToFlutterWith:@"app_lifecycle_changed_key" arguments:@{@"lifecycleState":@0}];
 }
 
 @end


### PR DESCRIPTION
移除[UIApplication sharedApplication].applicationState == UIApplicationStateActive的判断