### PR TITLE
对外暴露FBFlutterViewContainer页面资源释放API

### DIFF
--- a/ios/Classes/container/FBFlutterViewContainer.h
+++ b/ios/Classes/container/FBFlutterViewContainer.h
@@ -32,6 +32,10 @@
 - (instancetype)init;
 - (void)surfaceUpdated:(BOOL)appeared;
 - (void)updateViewportMetrics;
+
+- (void)detachFlutterEngineIfNeeded;
+- (void)notifyWillDealloc;
+
 @end
 
 


### PR DESCRIPTION
在夸克iOS中会对FBFlutterViewContainer进行包装，其内部自动资源方式在这种情况一下，已经不再适用