### PR TITLE
popUntil使用containers列表不能保证顺序性，在同步popRoute过程会导致出现containers的乱序。需要通过提前clone队列进行保证

### DIFF
--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -340,8 +340,9 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     }
 
     if (targetContainer != null && targetContainer != topContainer) {
-      for (int index = containers.length - 1; index > popUntilIndex; index--) {
-        BoostContainer container = containers[index];
+      List<BoostContainer> _containersTemp = [...containers];
+      for (int index = _containersTemp.length - 1; index > popUntilIndex; index--) {
+        BoostContainer container = _containersTemp[index];
         final params = CommonParams()
           ..pageName = container.pageInfo.pageName
           ..uniqueId = container.pageInfo.uniqueId

--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -340,6 +340,8 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     }
 
     if (targetContainer != null && targetContainer != topContainer) {
+      /// containers item index would change when call 'nativeRouterApi.popRoute' method with sync.
+      /// clone containers keep original item index.
       List<BoostContainer> _containersTemp = [...containers];
       for (int index = _containersTemp.length - 1; index > popUntilIndex; index--) {
         BoostContainer container = _containersTemp[index];


### PR DESCRIPTION
popUntil使用containers列表不能保证顺序性，在同步popRoute过程会导致出现containers的乱序。需要通过提前clone队列进行保证