### PR TITLE
[dart] 修复应用启动首次访问flutter页面白屏问题

### DIFF
--- a/lib/src/boost_flutter_router_api.dart
+++ b/lib/src/boost_flutter_router_api.dart
@@ -18,6 +18,7 @@ class BoostFlutterRouterApi extends FlutterRouterApi {
   final FlutterBoostAppState appState;
   static BoostFlutterRouterApi _instance;
 
+  /// Whether the dart env is ready to receive messages from host.
   bool _isEnvReady = false;
   bool get isEnvReady => _isEnvReady;
   set isEnvReady(bool ready) => _isEnvReady = ready;
@@ -87,9 +88,8 @@ class BoostFlutterRouterApi extends FlutterRouterApi {
     });
   }
 
-  /// Add an [operation] in [BoostOperationQueue] if the [overlayKey.currentState] == null
-  /// [operation] will execute if the [overlayKey.currentState] != null
-  /// return the [operation] is added in queue or not
+  /// If [isEnvReady] is false, add [operation] into pending queue,
+  /// or [operation] will execute immediately.
   void _addInOperationQueueOrExcute(Function operation) {
     if (operation == null) {
       return;

--- a/lib/src/boost_flutter_router_api.dart
+++ b/lib/src/boost_flutter_router_api.dart
@@ -18,6 +18,10 @@ class BoostFlutterRouterApi extends FlutterRouterApi {
   final FlutterBoostAppState appState;
   static BoostFlutterRouterApi _instance;
 
+  bool _isEnvReady = false;
+  bool get isEnvReady => _isEnvReady;
+  set isEnvReady(bool ready) => _isEnvReady = ready;
+
   @override
   void pushRoute(CommonParams arg) {
     _addInOperationQueueOrExcute(() {
@@ -90,7 +94,7 @@ class BoostFlutterRouterApi extends FlutterRouterApi {
     if (operation == null) {
       return;
     }
-    if (overlayKey.currentState == null) {
+    if (!isEnvReady) {
       BoostOperationQueue.instance.addPendingOperation(operation);
     } else {
       operation.call();

--- a/lib/src/container_overlay.dart
+++ b/lib/src/container_overlay.dart
@@ -67,9 +67,8 @@ class ContainerOverlay {
   ///[mode] : The [BoostSpecificEntryRefreshMode] you want to choose
   void refreshSpecificOverlayEntries(
       BoostContainer container, BoostSpecificEntryRefreshMode mode) {
-    //Get OverlayState from global key
-    // The |overlayState| is null if there is no widget in the tree that matches
-    // this global key.
+    // The |overlayState| is null if there is no widget in the tree
+    // that matches this global key.
     final overlayState = overlayKey.currentState;
     if (overlayState == null) {
       Logger.error('Oops, Failed to update overlay. mode=$mode, $container');

--- a/lib/src/container_overlay.dart
+++ b/lib/src/container_overlay.dart
@@ -4,6 +4,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import 'boost_container.dart';
+import 'logger.dart';
 
 final GlobalKey<OverlayState> overlayKey = GlobalKey<OverlayState>();
 
@@ -67,8 +68,11 @@ class ContainerOverlay {
   void refreshSpecificOverlayEntries(
       BoostContainer container, BoostSpecificEntryRefreshMode mode) {
     //Get OverlayState from global key
+    // The |overlayState| is null if there is no widget in the tree that matches
+    // this global key.
     final overlayState = overlayKey.currentState;
     if (overlayState == null) {
+      Logger.error('Oops, Failed to update overlay. mode=$mode, $container');
       return;
     }
 

--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -94,7 +94,10 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
 
     /// create the container matching the initial route
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      refreshOnPush(initialContainer);
+      // TODO(rulong.crl): To reuse the initial Container
+      if (topContainer == initialContainer) {
+        refreshOnPush(initialContainer);
+      }
       _addAppLifecycleStateEventListener();
       BoostOperationQueue.instance.runPendingOperations();
     });

--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -94,6 +94,8 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     _containers.add(initialContainer);
     super.initState();
 
+    // Make sure that the widget in the tree that matches [overlayKey]
+    // is already mounted, or [refreshOnPush] will fail.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       refreshOnPush(initialContainer);
       _boostFlutterRouterApi.isEnvReady = true;

--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -87,17 +87,16 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
         'please refer to "class CustomFlutterBinding" in example project');
     _nativeRouterApi = NativeRouterApi();
     _boostFlutterRouterApi = BoostFlutterRouterApi(this);
+
+    /// create the container matching the initial route
     final BoostContainer initialContainer =
         _createContainer(PageInfo(pageName: widget.initialRoute));
     _containers.add(initialContainer);
     super.initState();
 
-    /// create the container matching the initial route
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      // TODO(rulong.crl): To reuse the initial Container
-      if (topContainer == initialContainer) {
-        refreshOnPush(initialContainer);
-      }
+      refreshOnPush(initialContainer);
+      _boostFlutterRouterApi.isEnvReady = true;
       _addAppLifecycleStateEventListener();
       BoostOperationQueue.instance.runPendingOperations();
     });


### PR DESCRIPTION
原因如下：
在用户没有设置初始路由的情况下，应用启动以后立即打开一个Flutter页面，
如果该消息到达dart时：FlutterBoostAppState已经调用initState，
但是addPostFrameCallback还未执行，就会出现目标页面与默认的初始路由顺序颠倒的问题。