### PR TITLE
[Android] 修复FlutterEngine空指针异常

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -210,14 +210,15 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
 
     @Override
     protected void onDestroy() {
+        stage = LifecycleStage.ON_DESTROY;
+        detachFromEngineIfNeeded();
+        textureHooker.onFlutterTextureViewRelease();
+
         // Get engine before |super.onDestroy| callback.
         FlutterEngine engine = getFlutterEngine();
         super.onDestroy();
-        stage = LifecycleStage.ON_DESTROY;
-        textureHooker.onFlutterTextureViewRelease();
-        engine.getLifecycleChannel().appIsResumed();
+        engine.getLifecycleChannel().appIsResumed(); // Go after |super.onDestroy|.
         FlutterBoost.instance().getPlugin().onContainerDestroyed(this);
-        detachFromEngineIfNeeded();
         if (DEBUG) Log.d(TAG, "#onDestroy: " + this);
     }
 


### PR DESCRIPTION
在super.onDestroy之后访问FlutterEngine，会出现空指针。

/cc @pkuyaoyao