### PR TITLE
feat: Android抛出popRoute代理回调

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ CheungSKei <180353389@qq.com>
 xujinping <804677682@qq.com>
 dengzq <956796570@qq.com>
 pkuyaoyao <525841634@qq.com>
+郭翰林 <2318560278@qq.com>

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostDelegate.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostDelegate.java
@@ -3,5 +3,7 @@ package com.idlefish.flutterboost;
 public interface FlutterBoostDelegate {
     void pushNativeRoute(FlutterBoostRouteOptions options);
     void pushFlutterRoute(FlutterBoostRouteOptions options);
-    boolean popRoute(FlutterBoostRouteOptions options);
+    default boolean popRoute(FlutterBoostRouteOptions options){
+        return  false;
+    }
 }

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostDelegate.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostDelegate.java
@@ -3,4 +3,5 @@ package com.idlefish.flutterboost;
 public interface FlutterBoostDelegate {
     void pushNativeRoute(FlutterBoostRouteOptions options);
     void pushFlutterRoute(FlutterBoostRouteOptions options);
+    boolean popRoute(FlutterBoostRouteOptions options);
 }

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -93,15 +93,28 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
 
     @Override
     public void popRoute(CommonParams params, Messages.Result<Void> result) {
-        String uniqueId = params.getUniqueId();
-        if (uniqueId != null) {
-            FlutterViewContainer container = FlutterContainerManager.instance().findContainerById(uniqueId);
-            if (container != null) {
-                container.finishContainer((Map<String, Object>) (Object) params.getArguments());
+        if (delegate != null) {
+            FlutterBoostRouteOptions options = new FlutterBoostRouteOptions.Builder()
+                    .pageName(params.getPageName())
+                    .uniqueId(params.getUniqueId())
+                    .arguments((Map<String, Object>) (Object) params.getArguments())
+                    .build();
+            boolean isHandle = delegate.popRoute(options);
+            //isHandle代表是否已经自定义处理，如果未自定义处理走默认逻辑
+            if (!isHandle) {
+                String uniqueId = params.getUniqueId();
+                if (uniqueId != null) {
+                    FlutterViewContainer container = FlutterContainerManager.instance().findContainerById(uniqueId);
+                    if (container != null) {
+                        container.finishContainer((Map<String, Object>) (Object) params.getArguments());
+                    }
+                    result.success(null);
+                } else {
+                    throw new RuntimeException("Oops!! The unique id is null!");
+                }
             }
-            result.success(null);
         } else {
-            throw new RuntimeException("Oops!! The unique id is null!");
+            throw new RuntimeException("FlutterBoostPlugin might *NOT* set delegate!");
         }
     }
 

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/MyFlutterBoostDelegate.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/MyFlutterBoostDelegate.java
@@ -1,6 +1,7 @@
 package com.idlefish.flutterboost.example;
 
 import android.content.Intent;
+import android.widget.Toast;
 
 import com.idlefish.flutterboost.FlutterBoost;
 import com.idlefish.flutterboost.FlutterBoostDelegate;
@@ -28,5 +29,12 @@ public class MyFlutterBoostDelegate implements FlutterBoostDelegate {
                 .urlParams(options.arguments())
                 .build(FlutterBoost.instance().currentActivity());
         FlutterBoost.instance().currentActivity().startActivity(intent);
+    }
+
+    @Override
+    public boolean popRoute(FlutterBoostRouteOptions options) {
+        //自定义popRoute处理逻辑,如果不想走默认处理逻辑返回true进行拦截
+        Toast.makeText(FlutterBoost.instance().currentActivity(), "自定义popRoute处理逻辑", Toast.LENGTH_SHORT).show();
+        return false;
     }
 }


### PR DESCRIPTION
抛出Android端popRoute代理回调，用于处理自定义pop逻辑。例如混合栈中自定义出栈逻辑