### PR TITLE
fix(Android):FlutterBoost开启FlutterBoostFragment页面导致状态栏颜色异常

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -141,10 +141,15 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
             getFlutterEngine().getLifecycleChannel().appIsResumed();
 
             // Update system UI overlays to match Flutter's desired system chrome style
-            Assert.assertNotNull(platformPlugin);
-            platformPlugin.updateSystemUiOverlays();
+            onUpdateSystemUiOverlays();
         }
        if (DEBUG) Log.d(TAG, "#onResume: isHidden=" + isHidden() + ", " + this);
+    }
+
+    // Update system UI overlays to match Flutter's desired system chrome style
+    protected void onUpdateSystemUiOverlays() {
+        Assert.assertNotNull(platformPlugin);
+        platformPlugin.updateSystemUiOverlays();
     }
 
     @Override


### PR DESCRIPTION
我司App支持黑白两色皮肤，关闭Flutter引擎针对Android一端自动修改状态栏颜色功能后，FlutterBoostFragment页面在白色皮肤下展示了白色的状态栏图标。

由于引擎自动修改状态栏颜色不可控，故我们关闭了Flutter引擎中自动改变状态栏颜色的逻辑，但是发现关闭Flutter引擎中的自动改变状态栏逻辑后，状态栏颜色依然不可控，最终排查定位到，在FlutterBoostFragment#onResume方法中，调用了platformPlugin.updateSystemUiOverlays()方法导致状态栏显示异常。

详情见issues：https://github.com/alibaba/flutter_boost/issues/1564