### PR TITLE
拦截器重构

### DIFF
--- a/example/lib/case/flutter_rebuild_demo.dart
+++ b/example/lib/case/flutter_rebuild_demo.dart
@@ -23,7 +23,8 @@ class _FlutterRebuildDemoState extends State<FlutterRebuildDemo> {
               padding: EdgeInsets.all(10),
               child: Text("push with container"),
               onPressed: () {
-                BoostNavigator.instance.push("flutterRebuildPageA", withContainer: true);
+                BoostNavigator.instance
+                    .push("flutterRebuildPageA", withContainer: true);
               },
             ),
             MaterialButton(
@@ -71,7 +72,8 @@ class _FlutterRebuildPageAState extends State<FlutterRebuildPageA> {
               padding: EdgeInsets.all(10),
               child: Text("push with container"),
               onPressed: () {
-                BoostNavigator.instance.push("flutterRebuildPageB", withContainer: true);
+                BoostNavigator.instance
+                    .push("flutterRebuildPageB", withContainer: true);
               },
             ),
             MaterialButton(
@@ -128,7 +130,3 @@ class _FlutterRebuildPageBState extends State<FlutterRebuildPageB> {
     );
   }
 }
-
-
-
-

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -69,31 +69,59 @@ class CustomFlutterBinding extends WidgetsFlutterBinding
 
 class CustomInterceptor1 extends BoostInterceptor {
   @override
-  void onPush(BoostInterceptorOption option, PushInterceptorHandler handler) {
-    Logger.log('CustomInterceptor1~~~, $option');
+  void onPrePush(
+      BoostInterceptorOption option, PushInterceptorHandler handler) {
+    Logger.log('CustomInterceptor#onPrePush1~~~, $option');
     // Add extra arguments
     option.arguments['CustomInterceptor1'] = "1";
-    super.onPush(option, handler);
+    super.onPrePush(option, handler);
+  }
+
+  @override
+  void onPostPush(
+      BoostInterceptorOption option, PushInterceptorHandler handler) {
+    Logger.log('CustomInterceptor#onPostPush1~~~, $option');
+    handler.next(option);
   }
 }
 
 class CustomInterceptor2 extends BoostInterceptor {
   @override
-  void onPush(BoostInterceptorOption option, PushInterceptorHandler handler) {
-    Logger.log('CustomInterceptor2~~~, $option');
+  void onPrePush(
+      BoostInterceptorOption option, PushInterceptorHandler handler) {
+    Logger.log('CustomInterceptor#onPrePush2~~~, $option');
     // Add extra arguments
     option.arguments['CustomInterceptor2'] = "2";
-    // handler.resolve(<String, dynamic>{'result': 'xxxx'});
+    if (option.isFromHost) {
+      handler.next(option);
+    } else {
+      handler.resolve(<String, dynamic>{'result': 'xxxx'});
+    }
+  }
+
+  @override
+  void onPostPush(
+      BoostInterceptorOption option, PushInterceptorHandler handler) {
+    Logger.log('CustomInterceptor#onPostPush2~~~, $option');
     handler.next(option);
   }
 }
 
 class CustomInterceptor3 extends BoostInterceptor {
   @override
-  void onPush(BoostInterceptorOption option, PushInterceptorHandler handler) {
-    Logger.log('CustomInterceptor3~~~, $option');
+  void onPrePush(
+      BoostInterceptorOption option, PushInterceptorHandler handler) {
+    assert(option.isFromHost);
+    Logger.log('CustomInterceptor#onPrePush3~~~, $option');
     // Replace arguments
     option.arguments = <String, dynamic>{'CustomInterceptor3': '3'};
+    handler.next(option);
+  }
+
+  @override
+  void onPostPush(
+      BoostInterceptorOption option, PushInterceptorHandler handler) {
+    Logger.log('CustomInterceptor#onPostPush3~~~, $option');
     handler.next(option);
   }
 }
@@ -259,6 +287,7 @@ class _MyAppState extends State<MyApp> {
                 uniqueId: uniqueId,
               ));
     },
+
     ///使用 BoostCacheWidget包裹你的页面时，可以解决push pageA->pageB->pageC 过程中，pageA，pageB 会多次 rebuild 的问题
     'flutterRebuildDemo': (settings, uniqueId) {
       return MaterialPageRoute(

--- a/example_new/lib/main.dart
+++ b/example_new/lib/main.dart
@@ -14,13 +14,16 @@ void main() {
 
   ///这里的CustomFlutterBinding调用务必不可缺少，用于控制Boost状态的resume和pause
   CustomFlutterBinding();
-  runApp(MyApp());
+  runApp(const MyApp());
 }
 
 ///创建一个自定义的Binding，继承和with的关系如下，里面什么都不用写
-class CustomFlutterBinding extends WidgetsFlutterBinding with BoostFlutterBinding {}
+class CustomFlutterBinding extends WidgetsFlutterBinding
+    with BoostFlutterBinding {}
 
 class MyApp extends StatefulWidget {
+  const MyApp({Key key}) : super(key: key);
+
   @override
   _MyAppState createState() => _MyAppState();
 }
@@ -63,34 +66,44 @@ class _MyAppState extends State<MyApp> {
     'tab1': (settings, uniqueId) {
       return CupertinoPageRoute(
         settings: settings,
-        builder: (_) => TabPage(color: Colors.blue,title: 'Tab1',),
+        builder: (_) => const TabPage(
+          color: Colors.blue,
+          title: 'Tab1',
+        ),
       );
     },
     'tab2': (settings, uniqueId) {
       return CupertinoPageRoute(
         settings: settings,
-        builder: (_) => TabPage(color: Colors.red,title: 'Tab2',),
+        builder: (_) => const TabPage(
+          color: Colors.red,
+          title: 'Tab2',
+        ),
       );
     },
     'tab3': (settings, uniqueId) {
       return CupertinoPageRoute(
         settings: settings,
-        builder: (_) => TabPage(color: Colors.orange,title: 'Tab3',),
+        builder: (_) => const TabPage(
+          color: Colors.orange,
+          title: 'Tab3',
+        ),
       );
     },
+
     ///生命周期例子页面
     'lifecyclePage': (settings, uniqueId) {
       return CupertinoPageRoute(
           settings: settings,
           builder: (ctx) {
-            return LifecycleTestPage();
+            return const LifecycleTestPage();
           });
     },
     'replacementPage': (settings, uniqueId) {
       return CupertinoPageRoute(
           settings: settings,
           builder: (ctx) {
-            return ReplacementPage();
+            return const ReplacementPage();
           });
     },
 
@@ -104,7 +117,7 @@ class _MyAppState extends State<MyApp> {
           ///背景蒙版颜色
           barrierColor: Colors.black12,
           settings: settings,
-          pageBuilder: (_, __, ___) => DialogPage());
+          pageBuilder: (_, __, ___) => const DialogPage());
     },
   };
 
@@ -120,6 +133,7 @@ class _MyAppState extends State<MyApp> {
     return MaterialApp(
       home: home,
       debugShowCheckedModeBanner: true,
+
       ///必须加上builder参数，否则showDialog等会出问题
       builder: (_, __) {
         return home;
@@ -136,7 +150,6 @@ class _MyAppState extends State<MyApp> {
   }
 }
 
-
 class TabPage extends StatelessWidget {
   final String title;
   final Color color;
@@ -145,8 +158,10 @@ class TabPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor:color,
-      body: Center(child: Text(title ?? '',style:TextStyle(fontSize: 25)),),
+      backgroundColor: color,
+      body: Center(
+        child: Text(title ?? '', style: const TextStyle(fontSize: 25)),
+      ),
     );
   }
 }

--- a/example_new/lib/pages/dialog_page.dart
+++ b/example_new/lib/pages/dialog_page.dart
@@ -21,12 +21,11 @@ class _DialogPageState extends State<DialogPage> {
         decoration: const BoxDecoration(
             color: Colors.white,
             borderRadius: BorderRadius.only(
-                topLeft: Radius.circular(30),
-                topRight: const Radius.circular(30))),
+                topLeft: Radius.circular(30), topRight: Radius.circular(30))),
         child: Material(
           child: CupertinoButton(
               color: Colors.deepPurpleAccent,
-              child: Text('点击退出弹窗'),
+              child: const Text('点击退出弹窗'),
               onPressed: () {
                 //这里退出依然要用Boost的导航器，而不是官方的Navigator
                 BoostNavigator.instance.pop();

--- a/example_new/lib/pages/lifecycle_test_page.dart
+++ b/example_new/lib/pages/lifecycle_test_page.dart
@@ -7,37 +7,37 @@ class AppLifecycleObserver with GlobalPageVisibilityObserver {
   @override
   void onBackground(Route route) {
     super.onBackground(route);
-    print("AppLifecycleObserver - ${route.settings.name} - onBackground");
+    Logger.log("AppLifecycleObserver - ${route.settings.name} - onBackground");
   }
 
   @override
   void onForeground(Route route) {
     super.onForeground(route);
-    print("AppLifecycleObserver ${route.settings.name} - onForground");
+    Logger.log("AppLifecycleObserver ${route.settings.name} - onForground");
   }
 
   @override
   void onPagePush(Route route) {
     super.onPagePush(route);
-    print("AppLifecycleObserver - ${route.settings.name}- onPagePush");
+    Logger.log("AppLifecycleObserver - ${route.settings.name}- onPagePush");
   }
 
   @override
   void onPagePop(Route route) {
     super.onPagePop(route);
-    print("AppLifecycleObserver - ${route.settings.name}- onPagePop");
+    Logger.log("AppLifecycleObserver - ${route.settings.name}- onPagePop");
   }
 
   @override
   void onPageHide(Route route) {
     super.onPageHide(route);
-    print("AppLifecycleObserver - ${route.settings.name}- onPageHide");
+    Logger.log("AppLifecycleObserver - ${route.settings.name}- onPageHide");
   }
 
   @override
   void onPageShow(Route route) {
     super.onPageShow(route);
-    print("AppLifecycleObserver - ${route.settings.name}- onPageShow");
+    Logger.log("AppLifecycleObserver - ${route.settings.name}- onPageShow");
   }
 }
 
@@ -54,25 +54,25 @@ class _LifecycleTestPageState extends State<LifecycleTestPage>
   @override
   void onBackground() {
     super.onBackground();
-    print("LifecycleTestPage - onBackground");
+    Logger.log("LifecycleTestPage - onBackground");
   }
 
   @override
   void onForeground() {
     super.onForeground();
-    print("LifecycleTestPage - onForeground");
+    Logger.log("LifecycleTestPage - onForeground");
   }
 
   @override
   void onPageHide() {
     super.onPageHide();
-    print("LifecycleTestPage - onPageHide");
+    Logger.log("LifecycleTestPage - onPageHide");
   }
 
   @override
   void onPageShow() {
     super.onPageShow();
-    print("LifecycleTestPage - onPageShow");
+    Logger.log("LifecycleTestPage - onPageShow");
   }
 
   @override
@@ -101,7 +101,7 @@ class _LifecycleTestPageState extends State<LifecycleTestPage>
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: CupertinoNavigationBar(
-        middle: Text('Lifecycle page'),
+        middle: const Text('Lifecycle page'),
         leading: CupertinoNavigationBarBackButton(
           onPressed: () {
             BoostNavigator.instance.pop();
@@ -112,10 +112,11 @@ class _LifecycleTestPageState extends State<LifecycleTestPage>
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text('simple lifecycle test page', style: TextStyle(fontSize: 24)),
+            const Text('simple lifecycle test page',
+                style: TextStyle(fontSize: 24)),
             const SizedBox(height: 40),
             CupertinoButton.filled(
-                child: Text('push simple page'),
+                child: const Text('push simple page'),
                 onPressed: () {
                   BoostNavigator.instance
                       .push("simplePage", withContainer: true);

--- a/example_new/lib/pages/main_page.dart
+++ b/example_new/lib/pages/main_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_boost/flutter_boost.dart';
 
@@ -20,7 +19,7 @@ class MainPage extends StatefulWidget {
 }
 
 class _MainPageState extends State<MainPage> {
-  TextEditingController _controller = TextEditingController();
+  final TextEditingController _controller = TextEditingController();
 
   GlobalKey<ScaffoldState> key = GlobalKey();
 
@@ -47,7 +46,7 @@ class _MainPageState extends State<MainPage> {
             decoration: BoxDecoration(
                 color: Colors.red, borderRadius: BorderRadius.circular(4)),
             child: Text('这是native传来的参数：${arguments.toString()}',
-                style: TextStyle(color: Colors.white)),
+                style: const TextStyle(color: Colors.white)),
           ),
         ));
       });
@@ -99,7 +98,8 @@ class _MainPageState extends State<MainPage> {
             }).then((value) => showTipIfNeeded(value.toString()));
       }),
       Model("push with flutter Navigator", () {
-        Navigator.of(context).pushNamed('simplePage', arguments: {'data': _controller.text});
+        Navigator.of(context)
+            .pushNamed('simplePage', arguments: {'data': _controller.text});
       }),
       Model("show dialog", () {
         showDialog(
@@ -114,7 +114,10 @@ class _MainPageState extends State<MainPage> {
                     alignment: Alignment.center,
                     height: 100,
                     width: 100,
-                    child: Material(child: Text('this is a dialog',style:TextStyle(fontSize: 25)),),
+                    child: const Material(
+                      child: Text('this is a dialog',
+                          style: TextStyle(fontSize: 25)),
+                    ),
                     color: Colors.redAccent,
                   ),
                 ),
@@ -164,7 +167,7 @@ class _MainPageState extends State<MainPage> {
               BoostNavigator.instance.pop();
             },
           ),
-          middle: Text('FlutterBoost Example'),
+          middle: const Text('FlutterBoost Example'),
         ),
         bottomNavigationBar: _buildBottomBar(),
         body: CustomScrollView(
@@ -176,7 +179,7 @@ class _MainPageState extends State<MainPage> {
             SliverToBoxAdapter(
                 child: Center(
               child: Text('Data String is: ${widget.data}',
-                  style: TextStyle(fontSize: 30)),
+                  style: const TextStyle(fontSize: 30)),
             )),
             emptyBox(0, 30),
             SliverList(
@@ -204,12 +207,12 @@ class _MainPageState extends State<MainPage> {
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: CupertinoTextField(
-          padding: EdgeInsets.symmetric(horizontal: 30, vertical: 20),
+          padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 20),
           controller: _controller,
           decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(5), color: Colors.amber),
           placeholder: 'input data ',
-          placeholderStyle: TextStyle(color: Colors.black38),
+          placeholderStyle: const TextStyle(color: Colors.black38),
         ),
       ),
     );
@@ -222,7 +225,7 @@ class _MainPageState extends State<MainPage> {
         padding: const EdgeInsets.symmetric(vertical: 15),
         onPressed: model.onTap,
         child: Text(model.title,
-            style: TextStyle(
+            style: const TextStyle(
                 fontSize: 20,
                 color: Colors.white,
                 fontWeight: FontWeight.w500)),
@@ -248,7 +251,7 @@ class _MainPageState extends State<MainPage> {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          Text(
+          const Text(
             'with container',
             style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
           ),

--- a/example_new/lib/pages/replacement_page.dart
+++ b/example_new/lib/pages/replacement_page.dart
@@ -15,7 +15,7 @@ class _ReplacementPageState extends State<ReplacementPage> {
     return Scaffold(
       body: Center(
         child: CupertinoButton.filled(
-            child: Text('back'),
+            child: const Text('back'),
             onPressed: () {
               BoostNavigator.instance.pop();
             }),

--- a/example_new/lib/pages/simple_page.dart
+++ b/example_new/lib/pages/simple_page.dart
@@ -12,7 +12,7 @@ class SimplePage extends StatefulWidget {
 }
 
 class _SimplePageState extends State<SimplePage> {
-  TextEditingController _controller = TextEditingController();
+  final TextEditingController _controller = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
@@ -30,27 +30,35 @@ class _SimplePageState extends State<SimplePage> {
           physics: const AlwaysScrollableScrollPhysics(),
           children: [
             const SizedBox(height: 100),
-            Align(alignment: Alignment.center,child: const Text("Simple flutter page", style: TextStyle(fontSize: 26))),
+            const Align(
+                alignment: Alignment.center,
+                child: Text("Simple flutter page",
+                    style: TextStyle(fontSize: 26))),
             const SizedBox(height: 50),
-            Align(alignment: Alignment.center,child: Text("data:${widget.data}", style: TextStyle(fontSize: 26))),
+            Align(
+                alignment: Alignment.center,
+                child: Text("data:${widget.data}",
+                    style: const TextStyle(fontSize: 26))),
             const SizedBox(height: 50),
             Padding(
                 padding: const EdgeInsets.all(8.0),
                 child: CupertinoTextField(
                   controller: _controller,
-                  padding: EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
                   placeholder: 'data to return previous page',
-                  decoration: BoxDecoration(color: Colors.amber),
+                  decoration: const BoxDecoration(color: Colors.amber),
                 )),
             const SizedBox(height: 10),
             Padding(
               padding: const EdgeInsets.all(8.0),
               child: CupertinoButton.filled(
-                padding: EdgeInsets.symmetric(vertical: 20, horizontal: 30),
+                padding:
+                    const EdgeInsets.symmetric(vertical: 20, horizontal: 30),
                 onPressed: () {
                   BoostNavigator.instance.pop(_controller.text);
                 },
-                child: Text('pop and return data',
+                child: const Text('pop and return data',
                     style: TextStyle(
                         fontSize: 20,
                         color: Colors.white,

--- a/example_new/test/widget_test.dart
+++ b/example_new/test/widget_test.dart
@@ -5,7 +5,4 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-
-void main() {
-
-}
+void main() {}

--- a/lib/src/boost_cache_widget.dart
+++ b/lib/src/boost_cache_widget.dart
@@ -7,7 +7,8 @@ class BoostCacheWidget extends StatefulWidget {
   final String uniqueId;
   final WidgetBuilder builder;
 
-  const BoostCacheWidget({@required this.uniqueId, @required this.builder, Key key})
+  const BoostCacheWidget(
+      {@required this.uniqueId, @required this.builder, Key key})
       : assert(builder != null),
         assert(uniqueId != null),
         super(key: key);

--- a/lib/src/boost_flutter_router_api.dart
+++ b/lib/src/boost_flutter_router_api.dart
@@ -18,14 +18,14 @@ class BoostFlutterRouterApi extends FlutterRouterApi {
   static BoostFlutterRouterApi _instance;
 
   /// Whether the dart env is ready to receive messages from host.
-  bool _isEnvReady = false;
-  bool get isEnvReady => _isEnvReady;
-  set isEnvReady(bool ready) => _isEnvReady = ready;
+  bool isEnvReady = false;
 
   @override
   void pushRoute(CommonParams arg) {
     _addInOperationQueueOrExcute(() {
-      appState.pushContainer(arg.pageName,
+      appState.pushWithInterceptor(
+          arg.pageName, true /* isFromHost */, true /* isFlutterPage */,
+          withContainer: true,
           uniqueId: arg.uniqueId,
           arguments:
               Map<String, dynamic>.from(arg.arguments ?? <String, dynamic>{}));
@@ -39,7 +39,6 @@ class BoostFlutterRouterApi extends FlutterRouterApi {
     });
   }
 
-  @override
   void popUntilRoute(CommonParams arg) {
     _addInOperationQueueOrExcute(() {
       appState.popUntil(route: arg.pageName, uniqueId: arg.uniqueId);

--- a/lib/src/boost_interceptor.dart
+++ b/lib/src/boost_interceptor.dart
@@ -4,7 +4,8 @@ import 'boost_navigator.dart';
 
 /// The request object in Interceptor,which is to passed
 class BoostInterceptorOption {
-  BoostInterceptorOption(this.name, {this.uniqueId, this.arguments});
+  BoostInterceptorOption(this.name,
+      {this.uniqueId, this.isFromHost, this.arguments});
 
   /// Your page name in route table
   String name;
@@ -12,12 +13,15 @@ class BoostInterceptorOption {
   /// Unique identifier for the route
   String uniqueId;
 
+  /// Whether or not the flutter page was opened by host
+  bool isFromHost;
+
   /// The arguments you want to pass in next page
   Map<String, dynamic> arguments;
 
   @override
-  String toString() =>
-      "Instance of 'BoostInterceptorOption'(name:$name, uniqueId:$uniqueId, arguments:$arguments)";
+  String toString() => "Instance of 'BoostInterceptorOption'(name:$name, "
+      "isFromHost:$isFromHost, uniqueId:$uniqueId, arguments:$arguments)";
 }
 
 enum InterceptorResultType {
@@ -69,7 +73,17 @@ class BoostInterceptor {
   ///
   /// If you want to complete the push with some custom data，
   /// you can resolve a [result] object with [handler.resolve].
+  void onPrePush(
+          BoostInterceptorOption option, PushInterceptorHandler handler) =>
+      handler.next(option);
+
+  /// The callback will be executed after the push have been finish.
   ///
-  void onPush(BoostInterceptorOption option, PushInterceptorHandler handler) =>
+  /// If have other interceptors, call [handler.next].
+  ///
+  /// If you want to complete the push finish event with some custom data，
+  /// you can resolve a [result] object with [handler.resolve].
+  void onPostPush(
+          BoostInterceptorOption option, PushInterceptorHandler handler) =>
       handler.next(option);
 }

--- a/lib/src/boost_lifecycle_binding.dart
+++ b/lib/src/boost_lifecycle_binding.dart
@@ -40,7 +40,7 @@ class BoostLifecycleBinding {
   /// callback event when showing on screen first time.
   /// Because it is not be added to [PageVisibilityBinding] before
   /// dispatching [containerDidShow] event
-  Set<String> _hasShownPageIds = <String>{};
+  final Set<String> _hasShownPageIds = <String>{};
 
   int getShownPageSize() {
     return _hasShownPageIds.length;

--- a/lib/src/boost_navigator.dart
+++ b/lib/src/boost_navigator.dart
@@ -3,10 +3,8 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 
 import 'boost_container.dart';
-import 'boost_interceptor.dart';
 import 'container_overlay.dart';
 import 'flutter_boost_app.dart';
-import 'messages.dart';
 
 typedef FlutterBoostRouteFactory = Route<dynamic> Function(
     RouteSettings settings, String uniqueId);
@@ -70,47 +68,10 @@ class BoostNavigator {
   Future<T> push<T extends Object>(String name,
       {Map<String, dynamic> arguments,
       bool withContainer = false,
-      bool opaque = true}) async {
-    var pushOption = BoostInterceptorOption(name,
-        arguments: arguments ?? <String, dynamic>{});
-    var future = Future<dynamic>(
-        () => InterceptorState<BoostInterceptorOption>(pushOption));
-    for (var interceptor in appState.interceptors) {
-      future = future.then<dynamic>((dynamic _state) {
-        final state = _state as InterceptorState<dynamic>;
-        if (state.type == InterceptorResultType.next) {
-          final pushHandler = PushInterceptorHandler();
-          interceptor.onPush(state.data, pushHandler);
-          return pushHandler.future;
-        } else {
-          return state;
-        }
-      });
-    }
-
-    return future.then((dynamic _state) {
-      final state = _state as InterceptorState<dynamic>;
-      if (state.data is BoostInterceptorOption) {
-        assert(state.type == InterceptorResultType.next);
-        pushOption = state.data;
-        if (isFlutterPage(pushOption.name)) {
-          return appState.pushWithResult(pushOption.name,
-              uniqueId: pushOption.uniqueId,
-              arguments: pushOption.arguments,
-              withContainer: withContainer,
-              opaque: opaque);
-        } else {
-          final params = CommonParams()
-            ..pageName = pushOption.name
-            ..arguments = pushOption.arguments;
-          appState.nativeRouterApi.pushNativeRoute(params);
-          return appState.pendNativeResult(pushOption.name);
-        }
-      } else {
-        assert(state.type == InterceptorResultType.resolve);
-        return Future<T>.value(state.data as T);
-      }
-    });
+      bool opaque = true}) {
+    return appState.pushWithInterceptor(
+        name, false /* isFromHost */, isFlutterPage(name),
+        arguments: arguments, withContainer: withContainer, opaque: opaque);
   }
 
   /// This api do two things
@@ -135,13 +96,14 @@ class BoostNavigator {
 
   /// PopUntil page off the hybrid stack.
   Future<void> popUntil({String route, String uniqueId}) async =>
-      await appState.popUntil(route: route, uniqueId: uniqueId);
+      appState.popUntil(route: route, uniqueId: uniqueId);
 
   /// Remove the page with the given [uniqueId] from hybrid stack.
   ///
   /// This API is for backwards compatibility.
   /// Please use [BoostNavigator.pop] instead.
-  Future<bool> remove(String uniqueId, {Map<String, dynamic> arguments}) async =>
+  Future<bool> remove(String uniqueId,
+          {Map<String, dynamic> arguments}) async =>
       appState.removeWithResult(uniqueId, arguments);
 
   /// Retrieves the infomation of the top-most flutter page

--- a/test/pop.dart
+++ b/test/pop.dart
@@ -29,11 +29,11 @@ class _MyAppState extends State<MyApp> {
             return Scaffold(
               body: Center(
                   child: Column(
-                    children: [
-                      Text('mainPage text'),
-                      Text(dataString ?? ''),
-                    ],
-                  )),
+                children: [
+                  Text('mainPage text'),
+                  Text(dataString ?? ''),
+                ],
+              )),
             );
           });
     },
@@ -46,11 +46,11 @@ class _MyAppState extends State<MyApp> {
             return Scaffold(
               body: Center(
                   child: Column(
-                    children: [
-                      Text('secondPage text'),
-                      Text(dataString ?? ''),
-                    ],
-                  )),
+                children: [
+                  Text('secondPage text'),
+                  Text(dataString ?? ''),
+                ],
+              )),
             );
           });
     },
@@ -78,7 +78,7 @@ class _MyAppState extends State<MyApp> {
   }
 }
 
-void main(){
+void main() {
   /// push and pop with result test
   testWidgets('push and pop with result test', (tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
拦截器重构：
1. 将onPush重命名为onPrePush（在该接口中可进行参数修改，阻止push等操作）
2. 增加onPostPush接口，实现push操作完成后通知业务 (需求来源：https://github.com/alibaba/flutter_boost/pull/1297)
3. 支持拦截从Native端打开的Flutter页面，主要用于修改参数 （相关问题：https://github.com/alibaba/flutter_boost/issues/1469 ）
