### PR TITLE
修复flutter首页打开A页面，打开B页面返回到首页后内存泄露问题

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,3 +41,4 @@ JunhuaLin <1075209054@qq.com>
 dengzq <956796570@qq.com>
 pkuyaoyao <525841634@qq.com>
 郭翰林 <2318560278@qq.com>
+qianhk <hongkai.qhk@alibaba-inc.com>

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -47,6 +47,10 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        final FlutterContainerManager containerManager = FlutterContainerManager.instance();
+        // try to detach prevous container from the engine.
+        FlutterViewContainer top = containerManager.getTopContainer();
+        if (top != null && top != this) top.detachFromEngineIfNeeded();
         super.onCreate(savedInstanceState);
         stage = LifecycleStage.ON_CREATE;
         flutterView = FlutterBoostUtils.findFlutterView(getWindow().getDecorView());

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/MyFlutterBoostDelegate.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/MyFlutterBoostDelegate.java
@@ -36,7 +36,7 @@ public class MyFlutterBoostDelegate implements FlutterBoostDelegate {
     @Override
     public boolean popRoute(FlutterBoostRouteOptions options) {
         //自定义popRoute处理逻辑,如果不想走默认处理逻辑返回true进行拦截
-        Toast.makeText(FlutterBoost.instance().currentActivity(), "自定义popRoute处理逻辑", Toast.LENGTH_SHORT).show();
+        Toast.makeText(FlutterBoost.instance().currentActivity().getApplicationContext(), "自定义popRoute处理逻辑", Toast.LENGTH_SHORT).show();
         return false;
     }
 }


### PR DESCRIPTION
发现boost android里存在FlutterBoostActivity内存泄露，经反复测试发现必现路径：工程自带的example也能重现：
native页面 -> 点open flutterPage(算Flutter首页) -> flutterRebuildDemo (算A页面) -> pushWithContainer (算B页面),
陆续关闭页面，从B 到 A，再Back A 到flutter首页，此时A activity泄露。

经分析，acvitiy onResume()里的detachFromEngineIfNeeded()调用，仅适用于页面返回时，deatch不需要的旧页面。
但新页面打开时，由于flutter引擎flutterView.detachFromFlutterEngine()内部做了isAttachedToFlutterEngine判断，此时deatch底部的页面无效，因为onCreate时已经创建了新的flutterView，因此在super.onCreate前加一个detach，此处刚好适应的是打开新页面的时机。

这样打开新页面，从旧页面返回就都有有效的detach了。