### PR TITLE
[Android] 当最顶层的Flutter容器处于后台时（例如，被Native容器遮挡/整个应用置后台），暂停帧调度

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## NEXT
+
+1. 修复flutter首页打开A页面，打开B页面返回到首页后内存泄露问题
+2. [bugfix] 1.解决异步导致的断言错误(#1583)；2.修改测试案例，解决测试页面被拦截的问题
+3. [Android] 完善PlatformView测试案例： 1. 增加复杂的Native动画场景； 2. 支持intent打开测试页面，方便自动化测试；
+4. 增加简单的WebView测试场景
+5. [Android] 当最顶层的Flutter容器处于后台时（例如，被Native容器遮挡/整个应用置后台），暂停帧调度
+
 ## v3.0-release.1
 1.  [ios]增加platform view测试案例 (#1546)
 2. [Android] 在Fragment的使用场景中，onHiddenChanged/setUserVisibleHint可能比onCreateView先调用 (#1456)
@@ -101,7 +109,7 @@ Breaking Change
 17. PageVisibility不再提供create和destroy方法，另外onPageCreate和onPageDestroy改名为onPagePush和onPagePop
 18. FIXED:同一个容器提供多个FlutterView,业务层通过remove(uniqueId)，指定id移除非首个flutterview会失效
 19. Boost接管handleAppLifecycleStateChanged，让Flutter生命周期与应用前后台对齐
-20. BoostNavigator添加pushReplacement方法，同时修复pop和findContainerById的逻辑 
+20. BoostNavigator添加pushReplacement方法，同时修复pop和findContainerById的逻辑
 21. 过滤内部路由RouteSettings.name为null的路由事件，如对话框路等非页面路由事件，否则影响正常页面生命周期
 22. [双端一致性] iOS端FBFlutterContainerManager与Android统一，FLutterBoostPlugin生命周期相关逻辑统一
 23. 调整 Flutter Engine 初始化流程，避免使用异步方式产生插件注册时序问题
@@ -242,7 +250,7 @@ The main changes are as following:
 From the point of API changes, we did some refactoring as following:
 #### iOS API changes
 1. FlutterBoostPlugin's startFlutterWithPlatform function change its parameter from FlutterViewController to Engine
-2. 
+2.
 **Before change**
 ```objectivec
 FlutterBoostPlugin
@@ -285,7 +293,7 @@ FlutterBoostPlugin2
 @protocol FLB2Platform <NSObject>
 @optional
 - (NSString *)entryForDart;
-    
+
 @required
 - (void)open:(NSString *)url
    urlParams:(NSDictionary *)urlParams

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -172,7 +172,13 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
 
         stage = LifecycleStage.ON_PAUSE;
         didFragmentHide();
-        getFlutterEngine().getLifecycleChannel().appIsResumed();
+        FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
+        // To avoid needless activity when the flutter container is in the
+        // background, we send |appIsResumed| iff the most-top flutter
+        // container remains resume state.
+        if (top != null && !top.isPausing()) {
+          getFlutterEngine().getLifecycleChannel().appIsResumed();
+        }
         if (DEBUG) Log.d(TAG, "#onPause: " + this + ", isFinshing=" + isFinishing);
     }
 
@@ -180,7 +186,13 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     public void onStop() {
         super.onStop();
         stage = LifecycleStage.ON_STOP;
-        getFlutterEngine().getLifecycleChannel().appIsResumed();
+        // To avoid needless activity when the flutter container is in the
+        // background, we send |appIsResumed| iff the most-top flutter
+        // container remains resume state.
+        FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
+        if (top != null && !top.isPausing()) {
+          getFlutterEngine().getLifecycleChannel().appIsResumed();
+        }
         if (DEBUG) Log.d(TAG, "#onStop: " + this);
     }
 
@@ -195,7 +207,13 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     public void onDetach() {
         FlutterEngine engine = getFlutterEngine();
         super.onDetach();
-        engine.getLifecycleChannel().appIsResumed();
+        // To avoid needless activity when the flutter container is in the
+        // background, we send |appIsResumed| iff the most-top flutter
+        // container remains resume state.
+        FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
+        if (top != null && !top.isPausing()) {
+          engine.getLifecycleChannel().appIsResumed();
+        }
         if (DEBUG) Log.d(TAG, "#onDetach: " + this);
     }
 

--- a/lib/src/boost_flutter_binding.dart
+++ b/lib/src/boost_flutter_binding.dart
@@ -18,9 +18,11 @@ mixin BoostFlutterBinding on WidgetsFlutterBinding {
 
   @override
   void handleAppLifecycleStateChanged(AppLifecycleState state) {
-    if (_appLifecycleStateLocked) {
-      return;
-    }
+    // TODO(0xZOne): In order to be able to pause frame scheduling while the
+    // Flutter container is in the background, we remove the restriction here.
+    // if (_appLifecycleStateLocked) {
+    //   return;
+    // }
     Logger.log('boost_flutter_binding: '
         'handleAppLifecycleStateChanged ${state.toString()}');
     super.handleAppLifecycleStateChanged(state);


### PR DESCRIPTION
解决部分场景下后台刷帧的问题（相关问题：https://ata.alibaba-inc.com/articles/236921）