### PR TITLE
[Android] 去掉不必要的兜底方案，解决Native页面返回值丢失的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## NEXT
+1. [Android] 去掉不必要的兜底方案，解决Native页面返回值丢失的问题
 
 v3.0-release.2
 1. 修复flutter首页打开A页面，打开B页面返回到首页后内存泄露问题

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -340,7 +340,10 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
                         Map<Object, Object> result = FlutterBoostUtils.bundleToMap(intent.getExtras());
                         params.setArguments(result);
                     }
+
+                    // Get a result back from an activity when it ends.
                     channel.onNativeResult(params, reply -> {
+                    if (DEBUG) Log.v(TAG, "#onNativeResult, pageName=" + pageName);
                     });
                 }
             } else {

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/NativePageActivity.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/NativePageActivity.java
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.idlefish.flutterboost.containers.FlutterBoostActivity;
 
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -69,6 +70,7 @@ public class NativePageActivity extends AppCompatActivity implements View.OnClic
         intent.putExtra("msg","This message is from NativePageActivity!!!");
         intent.putExtra("bool", true);
         intent.putExtra("int", 666);
+        intent.putExtra("time", Calendar.getInstance().getTime().toString());
         setResult(Activity.RESULT_OK, intent);
         super.finish();
     }

--- a/example/lib/flutter_page.dart
+++ b/example/lib/flutter_page.dart
@@ -146,7 +146,7 @@ class _FlutterRouteWidgetState extends State<FlutterRouteWidget>
                     )),
                 onTap: () => BoostNavigator.instance
                     .push("native")
-                    .then((value) => print("return:${value?.toString()}")),
+                    .then((value) => print("Return from Native: ${value?.toString()}")),
               ),
               InkWell(
                 child: Container(

--- a/lib/src/boost_interceptor.dart
+++ b/lib/src/boost_interceptor.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'boost_navigator.dart';
 
 /// The request object in Interceptor,which is to passed
@@ -45,7 +43,7 @@ class _BaseHandler {
 class PushInterceptorHandler extends _BaseHandler {
   /// Continue to call the next push interceptor.
   void next(BoostInterceptorOption options) {
-    _state = new InterceptorState<BoostInterceptorOption>(options);
+    _state = InterceptorState<BoostInterceptorOption>(options);
   }
 
   /// Return the result directly!

--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -603,18 +603,6 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     Logger.log('onNativeResult, key:$key, result:${params.arguments}');
   }
 
-  void _completePendingNativeResultIfNeeded(String initiatorPage) {
-    _pendingResult.keys
-        .where((element) => element.startsWith('$initiatorPage#'))
-        .toList()
-        .forEach((key) {
-      _pendingResult[key].complete();
-      _pendingResult.remove(key);
-      Logger.log('_completePendingNativeResultIfNeeded, '
-          'key:$key, size:${_pendingResult.length}');
-    });
-  }
-
   void _completePendingResultIfNeeded<T extends Object>(String uniqueId,
       {T result}) {
     if (uniqueId != null && _pendingResult.containsKey(uniqueId)) {
@@ -626,14 +614,6 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
   void onContainerShow(CommonParams params) {
     final container = _findContainerByUniqueId(params.uniqueId);
     BoostLifecycleBinding.instance.containerDidShow(container);
-
-    // Try to complete pending native result when container closed.
-    final topPage = topContainer?.topPage?.pageInfo?.uniqueId;
-    assert(topPage != null);
-    Future<void>.delayed(
-      const Duration(seconds: 1),
-      () => _completePendingNativeResultIfNeeded(topPage),
-    );
   }
 
   void onContainerHide(CommonParams params) {


### PR DESCRIPTION
对于Android Native页面，在onActivityResult回调中处理即可（[#pull/1108](https://github.com/alibaba/flutter_boost/pull/1108) 合入后不再需要该兜底方案）。