### PR TITLE
修复  onPostPush 和 onPostPush 类型强转失败

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,4 @@ dengzq <956796570@qq.com>
 pkuyaoyao <525841634@qq.com>
 郭翰林 <2318560278@qq.com>
 qianhk <hongkai.qhk@alibaba-inc.com>
+法的空间 <zmtzawqlp@live.com>

--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -253,12 +253,14 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     for (var interceptor in interceptors) {
       final pushHandler = PushInterceptorHandler();
       interceptor.onPrePush(state!.data, pushHandler);
-      state = pushHandler.state as InterceptorState<BoostInterceptorOption>?;
-      if (state!.type != InterceptorResultType.next) {
+
+      // user resolve or do nothing
+      if (pushHandler.state?.type != InterceptorResultType.next) {
         Logger.log('The page was intercepted by user. name:$name, '
             'isFromHost=$isFromHost, isFlutterPage=$isFlutterPage');
         return Future<T>.value(state.data as T);
       }
+      state = pushHandler.state as InterceptorState<BoostInterceptorOption>?;
     }
 
     if (state?.type == InterceptorResultType.next) {
@@ -373,10 +375,11 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
     for (var interceptor in interceptors) {
       final pushHandler = PushInterceptorHandler();
       interceptor.onPostPush(state!.data, pushHandler);
-      state = pushHandler.state as InterceptorState<BoostInterceptorOption>?;
-      if (state!.type != InterceptorResultType.next) {
+      // user resolve or do nothing
+      if (pushHandler.state?.type != InterceptorResultType.next) {
         break;
       }
+      state = pushHandler.state as InterceptorState<BoostInterceptorOption>?;
     }
   }
 


### PR DESCRIPTION
onPostPush 和 onPostPush 中
1. 用户 reslove 之后，不应该强转成 BoostInterceptorOption
2. 用户 在方法中不调用 handler，应该也算是 终止