### PR TITLE
[Android]fix popUntil not working

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -43,3 +43,4 @@ pkuyaoyao <525841634@qq.com>
 郭翰林 <2318560278@qq.com>
 qianhk <hongkai.qhk@alibaba-inc.com>
 法的空间 <zmtzawqlp@live.com>
+joechan-cq <1787678994@qq.com>

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -124,6 +124,9 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
                 } else {
                     throw new RuntimeException("Oops!! The unique id is null!");
                 }
+            } else {
+                //被拦截处理了，那么直接通知result
+                result.success(null);
             }
         } else {
             throw new RuntimeException("FlutterBoostPlugin might *NOT* set delegate!");


### PR DESCRIPTION
[Android] 修复Java层重写FlutterBoostDelegate中的popRoute方法后，导致dart层popUntil方法失效，只能回退1层的bug
#1710 