### PR TITLE
[Android] 与纯Flutter应用生命周期行为保持一致：应用切换到后台时，暂停帧调度，解决动画残影的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 1. [Android]fix popUntil not working (#1718)
 2. Add demo for afterimage test
+3. [Android] 与纯Flutter应用生命周期行为保持一致：应用切换到后台时，暂停帧调度，解决动画残影的问题。[注意] 应用「务必」确保前后台通知事件（onBackground/onForeground）的准确性（必要时通过dispatchBackForegroundEvent接口进行接管），否则可能出现页面假死现象；
 
 ## 4.0.4
 1. 修复 onPostPush 和 onPostPush 类型强转失败 (#1707)

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -271,6 +271,9 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
             CommonParams params = new CommonParams();
             channel.onForeground(params, reply -> {
             });
+
+            // The scheduling frames are resumed when [onForeground] is called.
+            changeFlutterAppLifecycle(FLUTTER_APP_STATE_RESUMED);
         } else {
             throw new RuntimeException("FlutterBoostPlugin might *NOT* have attached to engine yet!");
         }
@@ -283,6 +286,9 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
             CommonParams params = new CommonParams();
             channel.onBackground(params, reply -> {
             });
+
+            // The scheduling frames are paused when [onBackground] is called.
+            changeFlutterAppLifecycle(FLUTTER_APP_STATE_PAUSED);
         } else {
             throw new RuntimeException("FlutterBoostPlugin might *NOT* have attached to engine yet!");
         }

--- a/example/lib/case/rotation_transition.dart
+++ b/example/lib/case/rotation_transition.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_boost/flutter_boost.dart';
 
 class RotationTranDemo extends StatefulWidget {
   RotationTranDemo({Key? key}) : super(key: key);
@@ -12,11 +13,12 @@ class RotationTranDemo extends StatefulWidget {
 }
 
 class RotationTranDemoState extends State<RotationTranDemo>
-    with TickerProviderStateMixin {
+    with TickerProviderStateMixin, PageVisibilityObserver {
   late AnimationController _controller;
   late Animation<double> _animation;
 
-  initState() {
+  @override
+  void initState() {
     super.initState();
     _controller = AnimationController(
         duration: const Duration(milliseconds: 3000),
@@ -34,14 +36,18 @@ class RotationTranDemoState extends State<RotationTranDemo>
     _controller.addListener(() {
       setState(() {});
     });
+    print("RotationTranDemo - initState");
   }
 
   @override
   void dispose() {
     _controller.dispose();
+    PageVisibilityBinding.instance.removeObserver(this);
     super.dispose();
+    print("RotationTranDemo - dispose");
   }
 
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
@@ -61,5 +67,36 @@ class RotationTranDemoState extends State<RotationTranDemo>
             ]),
       ),
     );
+  }
+
+  @override
+  void onBackground() {
+    super.onBackground();
+    print("RotationTranDemo - onBackground");
+  }
+
+  @override
+  void onForeground() {
+    super.onForeground();
+    print("RotationTranDemo - onForeground");
+  }
+
+  @override
+  void onPageHide() {
+    super.onPageHide();
+    print("RotationTranDemo - onPageHide");
+  }
+
+  @override
+  void onPageShow() {
+    super.onPageShow();
+    print("RotationTranDemo - onPageShow");
+  }
+
+  @override
+  void didChangeDependencies() {
+    PageVisibilityBinding.instance.addObserver(this, ModalRoute.of(context)!);
+    super.didChangeDependencies();
+    print("RotationTranDemo - didChangeDependencies");
   }
 }


### PR DESCRIPTION
[注意] 应用「务必」确保前后台通知事件（onBackground/onForeground）的准确性，必要时通过dispatchBackForegroundEvent接管，否则可能出现页面假死现象；

相关问题：https://github.com/alibaba/flutter_boost/issues/1715, https://github.com/alibaba/flutter_boost/issues/1686