### PR TITLE
处理在单个activity页面有多个fragment时的焦点问题

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,3 +44,4 @@ pkuyaoyao <525841634@qq.com>
 qianhk <hongkai.qhk@alibaba-inc.com>
 法的空间 <zmtzawqlp@live.com>
 joechan-cq <1787678994@qq.com>
+Mafanwei <eraofma@qq.com>


### PR DESCRIPTION
比如底tab是安卓原生，然后有多个flutter fragment 子tab，多个fragment都会resume，最后变成只有最后一个页面拿到了焦点，此时切换到其他页面，因无焦点，所以不可滑动，不可点击。
此情况给予开发者自行控制。