### PR TITLE
[Android]fix popUntil not working (#1718)

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -118,6 +118,9 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
                 } else {
                     throw new RuntimeException("Oops!! The unique id is null!");
                 }
+            } else {
+                //被拦截处理了，那么直接通知result
+                result.success(null);
             }
         } else {
             throw new RuntimeException("FlutterBoostPlugin might *NOT* set delegate!");


### PR DESCRIPTION
* fix popUntil not working

[Android] 修复Java层重写FlutterBoostDelegate中的popRoute方法后，导致dart层popUntil方法失效，只能回退1层的bug