### PR TITLE
[Android] 解决FlutterBoostFragment切换时可能闪现上一个页面的问题

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ qianhk <hongkai.qhk@alibaba-inc.com>
 法的空间 <zmtzawqlp@live.com>
 joechan-cq <1787678994@qq.com>
 Roger Luo<tjrogertj@gmail.com>
+huan10 <huanly.w@gmail.com>

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -319,7 +319,6 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
         } else {
             throw new RuntimeException("FlutterBoostPlugin might *NOT* have attached to engine yet!");
         }
-        Log.v(TAG, "## onContainerHide: " + uniqueId);
     }
 
     public void onContainerCreated(FlutterViewContainer container) {
@@ -330,12 +329,16 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
         }
     }
 
-    public void onContainerAppeared(FlutterViewContainer container) {
+    public void onContainerAppeared(FlutterViewContainer container, Runnable onPushRouteComplete) {
         String uniqueId = container.getUniqueId();
         if (DEBUG) Log.v(TAG, "#onContainerAppeared: " + uniqueId);
         FlutterContainerManager.instance().activateContainer(uniqueId, container);
-        pushRoute(uniqueId, container.getUrl(), container.getUrlParams(), reply -> {});
-        onContainerShow(uniqueId);
+        pushRoute(uniqueId, container.getUrl(), container.getUrlParams(), reply -> {
+            if (onPushRouteComplete != null) {
+                onPushRouteComplete.run();
+            }
+            onContainerShow(uniqueId);
+        });
     }
 
     public void onContainerDisappeared(FlutterViewContainer container) {

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -114,15 +114,16 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
         FlutterViewContainer top = containerManager.getTopContainer();
         if (top != null && top != this) top.detachFromEngineIfNeeded();
 
-        performAttach();
         textureHooker.onFlutterTextureViewRestoreState();
-        FlutterBoost.instance().getPlugin().onContainerAppeared(this);
+        FlutterBoost.instance().getPlugin().onContainerAppeared(this, () -> {
+            performAttach();
 
-        // Since we takeover PlatformPlugin from FlutterActivityAndFragmentDelegate,
-        // the system UI overlays can't be updated in |onPostResume| callback. So we
-        // update system UI overlays to match Flutter's desired system chrome style here.
-        Assert.assertNotNull(platformPlugin);
-        platformPlugin.updateSystemUiOverlays();
+            // Since we takeover PlatformPlugin from FlutterActivityAndFragmentDelegate,
+            // the system UI overlays can't be updated in |onPostResume| callback. So we
+            // update system UI overlays to match Flutter's desired system chrome style here.
+            Assert.assertNotNull(platformPlugin);
+            platformPlugin.updateSystemUiOverlays();
+        });
         if (DEBUG) Log.d(TAG, "#onResume: " + this + ", isOpaque=" + isOpaque());
     }
 

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -112,7 +112,7 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
         if (hidden) {
             didFragmentHide();
         } else {
-            didFragmentShow();
+            didFragmentShow(() -> {});
         }
         if (DEBUG) Log.d(TAG, "#onHiddenChanged: hidden="  + hidden + ", " + this);
     }
@@ -124,7 +124,7 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
         // we just return here.
         if (flutterView == null) return;
         if (isVisibleToUser) {
-            didFragmentShow();
+            didFragmentShow(() -> {});
         } else {
             didFragmentHide();
         }
@@ -147,10 +147,10 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
 
         stage = LifecycleStage.ON_RESUME;
         if (!isHidden()) {
-            didFragmentShow();
-
-            // Update system UI overlays to match Flutter's desired system chrome style
-            onUpdateSystemUiOverlays();
+            didFragmentShow(() -> {
+                // Update system UI overlays to match Flutter's desired system chrome style
+                onUpdateSystemUiOverlays();
+            });
         }
        if (DEBUG) Log.d(TAG, "#onResume: isHidden=" + isHidden() + ", " + this);
     }
@@ -297,15 +297,17 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
         return (stage == LifecycleStage.ON_PAUSE || stage == LifecycleStage.ON_STOP) && !isFinishing;
     }
 
-    protected void didFragmentShow() {
+    protected void didFragmentShow(Runnable onComplete) {
         // try to detach prevous container from the engine.
         FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
         if (top != null && top != this) {
             top.detachFromEngineIfNeeded();
         }
 
-        FlutterBoost.instance().getPlugin().onContainerAppeared(this);
-        performAttach();
+        FlutterBoost.instance().getPlugin().onContainerAppeared(this, () -> {
+            performAttach();
+            onComplete.run();
+        });
         textureHooker.onFlutterTextureViewRestoreState();
         if (DEBUG) Log.d(TAG, "#didFragmentShow: " + this + ", isOpaque=" + isOpaque());
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     lintOptions {
         disable 'InvalidPackage'
@@ -35,7 +35,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.idlefish.flutterboost.example"
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostView.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostView.java
@@ -129,9 +129,9 @@ public class FlutterBoostView extends LifecycleView implements FlutterViewContai
             onCreate();
         }
         super.onResume();
-        FlutterBoost.instance().getPlugin().onContainerAppeared(this);
-        flutterView().attachToFlutterEngine(getFlutterEngine());
-        getFlutterEngine().getLifecycleChannel().appIsResumed();
+        FlutterBoost.instance().getPlugin().onContainerAppeared(this, () -> {
+            flutterView().attachToFlutterEngine(getFlutterEngine());
+        });
     }
 
     @Override
@@ -139,7 +139,6 @@ public class FlutterBoostView extends LifecycleView implements FlutterViewContai
         if(hasDestroyed()) return;
         super.onPause();
         flutterView().detachFromFlutterEngine();
-        getFlutterEngine().getLifecycleChannel().appIsResumed();
     }
 
     @Override
@@ -167,8 +166,9 @@ public class FlutterBoostView extends LifecycleView implements FlutterViewContai
         }
 
         if (getVisibility() == View.VISIBLE) {
-            FlutterBoost.instance().getPlugin().onContainerAppeared(this);
-            flutterView().attachToFlutterEngine(getFlutterEngine());
+            FlutterBoost.instance().getPlugin().onContainerAppeared(this, () -> {
+                flutterView().attachToFlutterEngine(getFlutterEngine());
+            });
         } else if (getVisibility() == View.GONE) {
             FlutterBoost.instance().getPlugin().onContainerDisappeared(this);
             flutterView().detachFromFlutterEngine();


### PR DESCRIPTION
业务同学反馈，切换FlutterBoostFragment时偶尔闪现上一个页面。

猜测的可能原因是，Native端的容器切换与Dart侧的切换不同步导致。也就是Native先切换过去了，显示了新页面，但是dart还没有切换，刷了一帧当前页面后，才切换到新页面。