### PR TITLE
[Android] 解决横/竖屏切换后，后退时闪现页面被拉伸（或压缩）的问题

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -118,12 +118,14 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
 
         stage = LifecycleStage.ON_RESUME;
 
-        // try to detach prevous container from the engine.
-        FlutterViewContainer top = containerManager.getTopContainer();
-        if (top != null && top != this) top.detachFromEngineIfNeeded();
-
         textureHooker.onFlutterTextureViewRestoreState();
+
+        FlutterViewContainer top = containerManager.getTopContainer();
         FlutterBoost.instance().getPlugin().onContainerAppeared(this, () -> {
+            // try to detach *prevous* container from the engine.
+            if (top != null && top != this) top.detachFromEngineIfNeeded();
+
+            // attach new container to the engine.
             attachToEngineIfNeeded();
 
             // Since we takeover PlatformPlugin from FlutterActivityAndFragmentDelegate,

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -15,6 +15,7 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -28,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import io.flutter.Log;
 import io.flutter.embedding.android.FlutterFragment;
 import io.flutter.embedding.android.FlutterTextureView;
 import io.flutter.embedding.android.FlutterView;
@@ -321,13 +321,13 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
 
     protected void didFragmentShow(Runnable onComplete) {
         if (isDebugLoggingEnabled()) Log.d(TAG, "#didFragmentShow: " + this + ", isOpaque=" + isOpaque());
-        // try to detach prevous container from the engine.
-        FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
-        if (top != null && top != this) {
-            top.detachFromEngineIfNeeded();
-        }
 
+        FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
         FlutterBoost.instance().getPlugin().onContainerAppeared(this, () -> {
+            // try to detach *prevous* container from the engine.
+            if (top != null && top != this) top.detachFromEngineIfNeeded();
+
+            // attach new container to the engine.
             attachToEngineIfNeeded();
             onComplete.run();
         });

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterContainerManager.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterContainerManager.java
@@ -5,18 +5,21 @@
 package com.idlefish.flutterboost.containers;
 
 import android.app.Activity;
+import android.os.Build;
+import android.util.Log;
+
+import com.idlefish.flutterboost.FlutterBoostUtils;
 
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 
-import io.flutter.Log;
-
 public class FlutterContainerManager {
-    private static final String TAG = FlutterContainerManager.class.getSimpleName();
-    private static final boolean DEBUG = true;
+    private static final String TAG = "FlutterBoost_java";
 
-    private FlutterContainerManager() {
+    private FlutterContainerManager() {}
+    private boolean isDebugLoggingEnabled() {
+        return FlutterBoostUtils.isDebugLoggingEnabled();
     }
 
     private static class LazyHolder {
@@ -33,7 +36,7 @@ public class FlutterContainerManager {
     // onContainerCreated
     public void addContainer(String uniqueId, FlutterViewContainer container) {
         allContainers.put(uniqueId, container);
-        if (DEBUG) Log.d(TAG, "#addContainer:" + toString());
+        if (isDebugLoggingEnabled()) Log.d(TAG, "#addContainer: " + uniqueId + ", " + this);
     }
 
     // onContainerAppeared
@@ -45,7 +48,7 @@ public class FlutterContainerManager {
             activeContainers.remove(container);
         }
         activeContainers.add(container);
-        if (DEBUG) Log.d(TAG, "#activateContainer:" + toString());
+        if (isDebugLoggingEnabled()) Log.d(TAG, "#activateContainer: " + uniqueId + "," + this);
     }
 
     // onContainerDestroyed
@@ -53,7 +56,7 @@ public class FlutterContainerManager {
         if (uniqueId == null) return;
         FlutterViewContainer container = allContainers.remove(uniqueId);
         activeContainers.remove(container);
-        if (DEBUG) Log.d(TAG, "#removeContainer:" + toString());
+        if (isDebugLoggingEnabled()) Log.d(TAG, "#removeContainer: " + uniqueId + ", " + this);
     }
 
 
@@ -101,10 +104,13 @@ public class FlutterContainerManager {
         return allContainers.size();
     }
 
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("activeContainers=" + activeContainers.size() + ", [");
-        activeContainers.forEach((value) -> sb.append(value.getUrl() + ','));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            activeContainers.forEach((value) -> sb.append(value.getUrl() + ','));
+        }
         sb.append("]");
         return sb.toString();
     }


### PR DESCRIPTION
将前一个容器从引擎detach的时机「推迟」到新容器的Dart页面push完成后，开始attach引擎之前，以便更新页面，避免呈现横/竖屏切换前的旧图像