### PR TITLE
Revert: "[Android] 解决横/竖屏切换后，后退时闪现页面被拉伸（或压缩）的问题 (#1857)"

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -120,11 +120,11 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
 
         textureHooker.onFlutterTextureViewRestoreState();
 
+        // try to detach *prevous* container from the engine.
         FlutterViewContainer top = containerManager.getTopContainer();
-        FlutterBoost.instance().getPlugin().onContainerAppeared(this, () -> {
-            // try to detach *prevous* container from the engine.
-            if (top != null && top != this) top.detachFromEngineIfNeeded();
+        if (top != null && top != this) top.detachFromEngineIfNeeded();
 
+        FlutterBoost.instance().getPlugin().onContainerAppeared(this, () -> {
             // attach new container to the engine.
             attachToEngineIfNeeded();
 

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -322,11 +322,11 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     protected void didFragmentShow(Runnable onComplete) {
         if (isDebugLoggingEnabled()) Log.d(TAG, "#didFragmentShow: " + this + ", isOpaque=" + isOpaque());
 
+        // try to detach *prevous* container from the engine.
         FlutterViewContainer top = FlutterContainerManager.instance().getTopContainer();
-        FlutterBoost.instance().getPlugin().onContainerAppeared(this, () -> {
-            // try to detach *prevous* container from the engine.
-            if (top != null && top != this) top.detachFromEngineIfNeeded();
+        if (top != null && top != this) top.detachFromEngineIfNeeded();
 
+        FlutterBoost.instance().getPlugin().onContainerAppeared(this, () -> {
             // attach new container to the engine.
             attachToEngineIfNeeded();
             onComplete.run();


### PR DESCRIPTION
Reason: 该修复方案可能导致后退截图可能不正确，即当前页面的截图与前一个页面的截图相同。该问题不能通过调整attch/detach的时机进行解决，暂时回滚。