### PR TITLE
[ios] 解决pop传参不能返回的问题

### DIFF
--- a/ios/Classes/FlutterBoostPlugin.m
+++ b/ios/Classes/FlutterBoostPlugin.m
@@ -145,12 +145,16 @@
     options.uniqueId = input.uniqueId;
     options.arguments = input.arguments;
     options.completion = ^(BOOL ret) {
-      completion(nil);
     };
 
-    //调用代理回调给调用层
+    // 调用代理回调给调用层
     [self.delegate popRoute:options];
-  };
+    completion(nil);
+  } else {
+    completion([FlutterError errorWithCode:@"Invalid uniqueId"
+                                   message:@"No container to pop."
+                                   details:nil]);
+  }
 }
 
 - (nullable FBStackInfo *)getStackFromHostWithError:(FlutterError *_Nullable *_Nonnull)error {


### PR DESCRIPTION
将completion放在FlutterBoostRouteOptions参数里让业务回调，容易被业务遗漏。当前对回调时机的精度要求不高，回调直接在内部处理，避免遗漏。

Related issue: https://github.com/alibaba/flutter_boost/issues/1867