### PR TITLE
Revert "fix #1863"

### DIFF
--- a/lib/src/boost_container.dart
+++ b/lib/src/boost_container.dart
@@ -131,11 +131,21 @@ class BoostContainerState extends State<BoostContainerWidget> {
   @override
   void initState() {
     super.initState();
+    container.addListener(_onRouteChanged);
   }
 
   @override
   void didUpdateWidget(covariant BoostContainerWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget != widget) {
+      oldWidget.container.removeListener(_onRouteChanged);
+      container.addListener(_onRouteChanged);
+    }
+  }
+
+  ///just refresh
+  void _onRouteChanged() {
+    setState(() {});
   }
 
   @override
@@ -161,6 +171,7 @@ class BoostContainerState extends State<BoostContainerWidget> {
 
   @override
   void dispose() {
+    container.removeListener(_onRouteChanged);
     super.dispose();
   }
 }

--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -327,9 +327,7 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
         arguments: arguments,
         withContainer: false);
     assert(topContainer != null);
-    var boostPage = BoostPage.create(pageInfo);
-    var result = topContainer!.addPage(boostPage);
-    topContainer!.navigator?.push(boostPage.route as Route<Object?>);
+    var result = topContainer!.addPage(BoostPage.create(pageInfo));
     _pushFinish(pageName, uniqueId: uniqueId, arguments: arguments);
     return result!.then((value) => value as T);
   }


### PR DESCRIPTION
Reverts alibaba/flutter_boost#1865

该 PR会引发[新问题](https://github.com/alibaba/flutter_boost/pull/1865#issuecomment-1683253289
)，先暂时回滚。

另外，https://github.com/alibaba/flutter_boost/issues/1863 问题的原因可能是，FlutterBoost为了无缝兼容原生的Navigator，混合使用了命令式和声明式两种路由API，引起了同步问题。