### PR TITLE
调整 flutter_boost_app 中 onWillPop 逻辑；修复 Android 状态栏相关问题；

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostUtils.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostUtils.java
@@ -21,6 +21,8 @@ import java.util.UUID;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.view.WindowInsetsControllerCompat;
+import androidx.fragment.app.FragmentActivity;
+
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -53,7 +55,7 @@ public class FlutterBoostUtils {
                         (Class<? extends FlutterPlugin>) Class.forName("com.idlefish.flutterboost.FlutterBoostPlugin");
                 return (FlutterBoostPlugin) engine.getPlugins().get(pluginClass);
             } catch (Throwable t) {
-              t.printStackTrace();
+                t.printStackTrace();
             }
         }
         return null;
@@ -61,15 +63,15 @@ public class FlutterBoostUtils {
 
     public static Map<String, Object> bundleToMap(Bundle bundle) {
         Map<String, Object> map = new HashMap<>();
-        if(bundle == null || bundle.keySet().isEmpty()) {
+        if (bundle == null || bundle.keySet().isEmpty()) {
             return map;
         }
         Set<String> keys = bundle.keySet();
         for (String key : keys) {
             Object value = bundle.get(key);
-            if(value instanceof Bundle) {
+            if (value instanceof Bundle) {
                 map.put(key, bundleToMap(bundle.getBundle(key)));
-            } else if (value != null){
+            } else if (value != null) {
                 map.put(key, value);
             }
         }
@@ -107,6 +109,20 @@ public class FlutterBoostUtils {
             }
         }
         return null;
+    }
+
+    public static void setCurrentSystemUiOverlayTheme(PlatformPlugin platformPlugin, PlatformChannel.SystemChromeStyle currentTheme) {
+        if (platformPlugin != null) {
+            try {
+                Field field = platformPlugin.getClass().getDeclaredField("currentTheme");
+                field.setAccessible(true);
+                field.set(platformPlugin, currentTheme);
+            } catch (NoSuchFieldException e) {
+                e.printStackTrace();
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     public static void setSystemChromeSystemUIOverlayStyle(@NonNull Activity activity,

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -43,9 +43,9 @@ import static com.idlefish.flutterboost.containers.FlutterActivityLaunchConfigs.
 public class FlutterBoostActivity extends FlutterActivity implements FlutterViewContainer {
     private static final String TAG = "FlutterBoost_java";
     private final String who = UUID.randomUUID().toString();
-    private final FlutterTextureHooker textureHooker =new FlutterTextureHooker();
+    private final FlutterTextureHooker textureHooker = new FlutterTextureHooker();
     private FlutterView flutterView;
-    protected PlatformPlugin platformPlugin;
+    private PlatformPlugin platformPlugin;
     private LifecycleStage stage;
     private boolean isAttached = false;
 
@@ -54,21 +54,24 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
     }
 
     @Override
+    public PlatformPlugin getPlatformPlugin() {
+        return platformPlugin;
+    }
+
+    @Override
     protected void onCreate(Bundle savedInstanceState) {
         if (isDebugLoggingEnabled()) Log.d(TAG, "#onCreate: " + this);
+        super.onCreate(savedInstanceState);
         final FlutterContainerManager containerManager = FlutterContainerManager.instance();
         // try to detach prevous container from the engine.
         FlutterViewContainer top = containerManager.getTopContainer();
         if (top != null && top != this) {
-            if (top instanceof FlutterBoostActivity) {
-                PlatformChannel.SystemChromeStyle preContainerTheme = FlutterBoostUtils.getCurrentSystemUiOverlayTheme(((FlutterBoostActivity) top).platformPlugin);
-                if (preContainerTheme != null) {
-                    FlutterBoostUtils.setSystemChromeSystemUIOverlayStyle(this, preContainerTheme);
-                }
+            PlatformChannel.SystemChromeStyle preContainerTheme = FlutterBoostUtils.getCurrentSystemUiOverlayTheme(top.getPlatformPlugin());
+            if (preContainerTheme != null) {
+                FlutterBoostUtils.setSystemChromeSystemUIOverlayStyle(this, preContainerTheme);
             }
             top.detachFromEngineIfNeeded();
         }
-        super.onCreate(savedInstanceState);
         stage = LifecycleStage.ON_CREATE;
         flutterView = FlutterBoostUtils.findFlutterView(getWindow().getDecorView());
         flutterView.detachFromFlutterEngine(); // Avoid failure when attaching to engine in |onResume|.
@@ -219,7 +222,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
             Field isDisplayingFlutterUiField = FlutterRenderer.class.getDeclaredField("isDisplayingFlutterUi");
             isDisplayingFlutterUiField.setAccessible(true);
             isDisplayingFlutterUiField.setBoolean(flutterRenderer, false);
-            assert(!flutterRenderer.isDisplayingFlutterUi());
+            assert (!flutterRenderer.isDisplayingFlutterUi());
         } catch (Exception e) {
             Log.e(TAG, "You *should* keep fields in io.flutter.embedding.engine.renderer.FlutterRenderer.");
             e.printStackTrace();
@@ -258,7 +261,8 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-        if (isDebugLoggingEnabled()) Log.d(TAG, "#onConfigurationChanged: " + (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE ? "LANDSCAPE" : "PORTRAIT") + ", " +  this);
+        if (isDebugLoggingEnabled())
+            Log.d(TAG, "#onConfigurationChanged: " + (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE ? "LANDSCAPE" : "PORTRAIT") + ", " + this);
     }
 
     @Override
@@ -335,7 +339,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
 
     @Override
     public Map<String, Object> getUrlParams() {
-        return (HashMap<String, Object>)getIntent().getSerializableExtra(EXTRA_URL_PARAM);
+        return (HashMap<String, Object>) getIntent().getSerializableExtra(EXTRA_URL_PARAM);
     }
 
     @Override
@@ -353,7 +357,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
 
     @Override
     public boolean isOpaque() {
-        return getBackgroundMode() ==  BackgroundMode.opaque;
+        return getBackgroundMode() == BackgroundMode.opaque;
     }
 
     @Override
@@ -391,7 +395,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
         }
 
         public FlutterBoostActivity.CachedEngineIntentBuilder urlParams(Map<String, Object> params) {
-            this.params = (params instanceof HashMap) ? (HashMap)params : new HashMap<String, Object>(params);
+            this.params = (params instanceof HashMap) ? (HashMap) params : new HashMap<String, Object>(params);
             return this;
         }
 

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -35,6 +35,7 @@ import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.android.RenderMode;
 import io.flutter.embedding.android.TransparencyMode;
 import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.plugin.platform.PlatformPlugin;
 
 public class FlutterBoostFragment extends FlutterFragment implements FlutterViewContainer {
@@ -46,9 +47,15 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     private LifecycleStage stage;
     private boolean isAttached = false;
     private boolean isFinishing = false;
+    private PlatformChannel.SystemChromeStyle currentTheme;
 
     private boolean isDebugLoggingEnabled() {
         return FlutterBoostUtils.isDebugLoggingEnabled();
+    }
+
+    @Override
+    public PlatformPlugin getPlatformPlugin() {
+        return platformPlugin;
     }
 
     @Override
@@ -205,7 +212,6 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     public void onDestroyView() {
         if (isDebugLoggingEnabled()) Log.d(TAG, "#onDestroyView: " + this);
         FlutterBoost.instance().getPlugin().onContainerDestroyed(this);
-
         super.onDestroyView();
     }
 
@@ -349,6 +355,9 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
 
         if (platformPlugin == null) {
             platformPlugin = new PlatformPlugin(getActivity(), getFlutterEngine().getPlatformChannel());
+            if (currentTheme != null) {
+                FlutterBoostUtils.setCurrentSystemUiOverlayTheme(platformPlugin, currentTheme);
+            }
         }
 
         // Attach rendering pipeline.
@@ -371,6 +380,7 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
     private void releasePlatformChannel() {
         if (isDebugLoggingEnabled()) Log.d(TAG, "#releasePlatformChannel: " + this);
         if (platformPlugin != null) {
+            currentTheme = FlutterBoostUtils.getCurrentSystemUiOverlayTheme(platformPlugin);
             platformPlugin.destroy();
             platformPlugin = null;
         }

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterViewContainer.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterViewContainer.java
@@ -6,18 +6,34 @@ package com.idlefish.flutterboost.containers;
 
 import android.app.Activity;
 
+import io.flutter.plugin.platform.PlatformPlugin;
+
 import java.util.Map;
 
 /**
  * A container which contains the FlutterView
  */
 public interface FlutterViewContainer {
+    PlatformPlugin getPlatformPlugin();
+
     Activity getContextActivity();
+
     String getUrl();
+
     Map<String, Object> getUrlParams();
+
     String getUniqueId();
+
     void finishContainer(Map<String, Object> result);
-    default boolean isPausing() { return false; }
-    default boolean isOpaque() { return true; }
-    default void detachFromEngineIfNeeded() {}
+
+    default boolean isPausing() {
+        return false;
+    }
+
+    default boolean isOpaque() {
+        return true;
+    }
+
+    default void detachFromEngineIfNeeded() {
+    }
 }

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostView.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostView.java
@@ -19,6 +19,7 @@ import io.flutter.embedding.android.LifecycleView;
 import io.flutter.embedding.android.RenderMode;
 import io.flutter.embedding.android.TransparencyMode;
 import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
+import io.flutter.plugin.platform.PlatformPlugin;
 
 import static com.idlefish.flutterboost.containers.FlutterActivityLaunchConfigs.EXTRA_UNIQUE_ID;
 import static com.idlefish.flutterboost.containers.FlutterActivityLaunchConfigs.EXTRA_URL;
@@ -36,6 +37,11 @@ public class FlutterBoostView extends LifecycleView implements FlutterViewContai
             Log.w(TAG, "Application attempted to call on a destroyed View", new Throwable());
         }
         return hasDestroyed;
+    }
+
+    @Override
+    public PlatformPlugin getPlatformPlugin() {
+        return null;
     }
 
     @NonNull
@@ -198,6 +204,7 @@ public class FlutterBoostView extends LifecycleView implements FlutterViewContai
       return getArguments().getString(ARG_CACHED_ENGINE_ID, FlutterBoost.ENGINE_ID);
     }
 
+    @Override
     public void onFlutterUiDisplayed() {
         if (callback != null) {
             callback.onFlutterUiDisplayed();
@@ -209,6 +216,7 @@ public class FlutterBoostView extends LifecycleView implements FlutterViewContai
         }
     }
 
+    @Override
     public void onFlutterUiNoLongerDisplayed() {
         if (callback != null) {
             callback.onFlutterUiNoLongerDisplayed();

--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -149,12 +149,12 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
   Widget build(BuildContext context) {
     return widget.appBuilder(WillPopScope(
         onWillPop: () async {
-          final canPop = topContainer!.navigator!.canPop();
-          if (canPop) {
-            topContainer!.navigator!.pop();
-            return true;
+          final topNavigator = topContainer!.navigator!;
+          if (topNavigator.canPop()) {
+            topNavigator.pop();
+            return false;
           }
-          return false;
+          return !topNavigator.canPop();
         },
         child: Listener(
             onPointerDown: _handlePointerDown,


### PR DESCRIPTION
关于状态栏修复说明：

修复状态栏异常问题

1. 跳转 FlutterBoostActivity 状态栏存在灰色过渡问题
2. 原生主页嵌套 FlutterBoostFragment 跳转 FlutterBoostActivity 状态栏默认设置失败
3. 修复 2 后，首次进入 FlutterBoostActivity 正常第二次异常

<br/>

问题1 分析：

setSystemChromeSystemUIOverlayStyle 调用太早，应该在 super 之后调用。因为 FlutterActivity 的 onCreate 中会调用 configureStatusBarForFullscreenFlutterExperience 将状态栏颜色设置为 0x40000000。

问题1 解决：

修改调用时机

<br/>

问题2 分析：

源逻辑检查 FlutterBoostActivity 才设置默认的状态栏颜色

问题2 解决：

调整状态栏设置逻辑，从 FlutterBoostActivity 调整为 FlutterViewContainer。直接从 TopContainer 获取，即使是 Fragment 也可以生效。

按理来说 FlutterBoostFragment 也应该使用类似 FlutterBoostActivity  的默认设置方式，但没有应用场景，暂时未作调整。

<br/>

问题3：

由于打开新页，执行 detachFromEngineIfNeeded 导致 topContainer platformPlugin 释放，新构建的 platformPlugin 没有 currentTheme 。再次进入新页时，反射获取 currentTheme 为空，导致新容器无法默认 topContainer 的主题

<br/>

问题3 解决：

在调用 detachFromEngineIfNeeded 时，保存 currentTheme 。当构建 platformPlugin 时，对 platformPlugin 的 currentTheme  进行赋值。