### PR TITLE
Add `mixin` modifier to avoid breaking user codes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## NEXT
+1. Add `mixin` modifier to avoid breaking user codes
 
 ## 5.0.0
 1. Fix the sample code's compilation errors on Flutter 3.16.x

--- a/lib/src/page_visibility.dart
+++ b/lib/src/page_visibility.dart
@@ -8,7 +8,7 @@ import 'package:flutter/scheduler.dart';
 import 'logger.dart';
 
 ///Observer for all pages visibility
-class GlobalPageVisibilityObserver {
+mixin class GlobalPageVisibilityObserver {
   void onPagePush(Route<dynamic> route) {}
 
   void onPageShow(Route<dynamic> route) {}
@@ -23,7 +23,7 @@ class GlobalPageVisibilityObserver {
 }
 
 ///Observer for single page visibility
-class PageVisibilityObserver {
+mixin class PageVisibilityObserver {
   ///
   /// Tip:If you want to do things when page is created,
   /// please in your [StatefulWidget]'s [State]


### PR DESCRIPTION
Note: Dart 3.0 no longer allows classes to be used as mixins by default.

Fixes: https://github.com/alibaba/flutter_boost/issues/1947