### PR TITLE
Adapt to the official engine's App Lifecycle state changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## NEXT
+1. Adapt to the official engine's App Lifecycle state changes
 
 ## 5.0.1
 1. Add `mixin` modifier to avoid breaking user codes

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoostPlugin.java
@@ -28,8 +28,9 @@ public class FlutterBoostPlugin implements FlutterPlugin, NativeRouterApi, Activ
     private static final String TAG = "FlutterBoost_java";
     private static final String APP_LIFECYCLE_CHANGED_KEY = "app_lifecycle_changed_key";
     private static final String LIFECYCLE_STATE = "lifecycleState";
-    private static final int FLUTTER_APP_STATE_RESUMED = 0;
-    private static final int FLUTTER_APP_STATE_PAUSED = 2;
+    // See https://github.com/flutter/engine/pull/42418 for details
+    private static final int FLUTTER_APP_STATE_RESUMED = 1;
+    private static final int FLUTTER_APP_STATE_PAUSED = 4;
 
     private FlutterEngine engine;
     private FlutterRouterApi channel;

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Classes/container/FBLifecycle.m
+++ b/ios/Classes/container/FBLifecycle.m
@@ -31,7 +31,7 @@
 @implementation FBLifecycle
 + (void)pause {
   [[FlutterBoost instance]sendEventToFlutterWith:@"app_lifecycle_changed_key"
-                                       arguments:@{@"lifecycleState":@2}];
+                                       arguments:@{@"lifecycleState":@4}];
   if (ENGINE.viewController != nil){
     ENGINE.viewController = nil;
   }
@@ -39,6 +39,6 @@
 
 + (void)resume {
   [[FlutterBoost instance]sendEventToFlutterWith:@"app_lifecycle_changed_key"
-                                       arguments:@{@"lifecycleState":@0}];
+                                       arguments:@{@"lifecycleState":@1}];
 }
 @end

--- a/lib/src/boost_flutter_binding.dart
+++ b/lib/src/boost_flutter_binding.dart
@@ -14,7 +14,6 @@ mixin BoostFlutterBinding on WidgetsFlutterBinding {
   void initInstances() {
     super.initInstances();
     _instance = this;
-    changeAppLifecycleState(AppLifecycleState.resumed);
   }
 
   static BoostFlutterBinding? get instance => _instance;

--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -122,9 +122,10 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
   void _addAppLifecycleStateEventListener() {
     _lifecycleStateListenerRemover = BoostChannel.instance
         .addEventListener(_appLifecycleChangedKey, (key, arguments) {
-      //we just deal two situation,resume and pause
-      //and 0 is resumed
-      //and 2 is paused
+      // we just deal two situation,resume and pause
+      // and 1 is resumed
+      // and 4 is paused
+      // See https://github.com/flutter/engine/pull/42418 for more details.
 
       final int? index = arguments["lifecycleState"];
 


### PR DESCRIPTION
Fix the following exception:

══╡ EXCEPTION CAUGHT BY SERVICES LIBRARY ╞══════════════════════════════════════════════════════════ The following assertion was thrown during a platform message callback: Invalid lifecycle state transition generated from AppLifecycleState.resumed to AppLifecycleState.detached (generated [AppLifecycleState.detached]) 'package:flutter/src/services/binding.dart':
Failed assertion: line 296 pos 12: '(){
      AppLifecycleState? starting = previousState;
      for (final AppLifecycleState ending in stateChanges) {
        if (!_debugVerifyLifecycleChange(starting, ending)) {
          return false;
        }
        starting = ending;
      }
      return true;
    }()'

Either the assertion indicates an error in the framework itself, or we should provide substantially more information in this error message to help you determine and fix the underlying cause. In either case, please report this assertion by filing a bug on GitHub:
  https://github.com/flutter/flutter/issues/new?template=2_bug.yml

When the exception was thrown, this was the stack: (elided 4 frames from class _AssertionError and dart:async) ════════════════════════════════════════════════════════════════════════════════════════════════════

See also: https://github.com/flutter/engine/pull/42418