### PR TITLE
使FlutterBoost支持Android Gradle Plugin 8.0及以上版本

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,3 +48,4 @@ Roger Luo<tjrogertj@gmail.com>
 huan10 <huanly.w@gmail.com>
 Starve-to-Death <506119631@qq.com>
 youyi-sizuru <xzpwork@gmail.com>
+wyq0918dev <815099246@qq.com>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.idlefish.flutterboost'
+    }
     compileSdkVersion 31
     buildToolsVersion '30.0.2'
     defaultConfig {


### PR DESCRIPTION
当Android主工程更新Android Gradle Plugin 8.0以后会强制要求在每一个library模块的build.gradle中标明命名空间namespace，**如果没有标注会直接抛出异常**。解决办法很简单，只需要在flutter_boost/android/build.gradle中添加代码
`
 if (project.android.hasProperty("namespace")) {
     namespace 'com.idlefish.flutterboost'
 }
`
即可修复，**通过判断语句可以向下兼容旧版**Android Gradle Plugin。可以参考flutter官方的几个plugin，都是通过这个方案同时兼容了新版和旧版的Android Gradle Plugin。