### PR TITLE
fix-1960

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostActivity.java
@@ -15,6 +15,7 @@ import android.util.Log;
 import com.idlefish.flutterboost.Assert;
 import com.idlefish.flutterboost.FlutterBoost;
 import com.idlefish.flutterboost.FlutterBoostUtils;
+import com.idlefish.flutterboost.invoke.RenderSurfaceHandler;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
@@ -69,6 +70,7 @@ public class FlutterBoostActivity extends FlutterActivity implements FlutterView
         super.onCreate(savedInstanceState);
         stage = LifecycleStage.ON_CREATE;
         flutterView = FlutterBoostUtils.findFlutterView(getWindow().getDecorView());
+        RenderSurfaceHandler.inject(flutterView);
         flutterView.detachFromFlutterEngine(); // Avoid failure when attaching to engine in |onResume|.
         FlutterBoost.instance().getPlugin().onContainerCreated(this);
     }

--- a/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/FlutterBoostFragment.java
@@ -24,6 +24,7 @@ import android.widget.FrameLayout;
 import com.idlefish.flutterboost.Assert;
 import com.idlefish.flutterboost.FlutterBoost;
 import com.idlefish.flutterboost.FlutterBoostUtils;
+import com.idlefish.flutterboost.invoke.RenderSurfaceHandler;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -116,6 +117,7 @@ public class FlutterBoostFragment extends FlutterFragment implements FlutterView
         FlutterBoost.instance().getPlugin().onContainerCreated(this);
         View view = super.onCreateView(inflater, container, savedInstanceState);
         flutterView = FlutterBoostUtils.findFlutterView(view);
+        RenderSurfaceHandler.inject(flutterView);
         // Detach FlutterView from engine before |onResume|.
         flutterView.detachFromFlutterEngine();
         if (view == flutterView) {

--- a/android/src/main/java/com/idlefish/flutterboost/invoke/RenderSurfaceHandler.java
+++ b/android/src/main/java/com/idlefish/flutterboost/invoke/RenderSurfaceHandler.java
@@ -1,0 +1,73 @@
+package com.idlefish.flutterboost.invoke;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import io.flutter.embedding.android.FlutterView;
+import io.flutter.embedding.engine.renderer.RenderSurface;
+
+/**
+ * 通过动态代理的方式，拦截RenderSurface(FlutterTextureView、FlutterSurfaceView)的接口调用。
+ *
+ * @author : joechan-cq
+ * @date : 2024/2/23 11:37
+ */
+public class RenderSurfaceHandler implements InvocationHandler {
+    private final Object target;
+
+    public RenderSurfaceHandler(Object target) {
+        this.target = target;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        // fix issue {https://github.com/alibaba/flutter_boost/issues/1960} with flutter 3.19
+        // 理想情况下，应该拦截resume方法，不过因为动态代理无法拦截内部调用，所以只能拦截attachToRender方法
+        // 为了减少影响，选择在调用startRenderingToSurface前（而不是detach后），将isPaused变量通过反射，设置为false
+        if ("attachToRenderer".equals(method.getName())) {
+            reflectAndSetVarPaused(target, false);
+        }
+        Object result = method.invoke(target, args);
+        return result;
+    }
+
+    private void reflectAndSetVarPaused(Object target, boolean value) {
+        if (target != null) {
+            try {
+                Field isPausedF = target.getClass().getDeclaredField("isPaused");
+                isPausedF.setAccessible(true);
+                boolean paused = isPausedF.getBoolean(target);
+                if (paused != value) {
+                    isPausedF.setBoolean(target, value);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public static void inject(FlutterView flutterView) {
+        if (flutterView != null) {
+            try {
+                Field renderSurfaceF = flutterView.getClass().getDeclaredField("renderSurface");
+                renderSurfaceF.setAccessible(true);
+                Object renderSurface = renderSurfaceF.get(flutterView);
+                if (renderSurface != null) {
+                    RenderSurfaceHandler handler = new RenderSurfaceHandler(renderSurface);
+
+                    // 创建动态代理对象
+                    RenderSurface proxy = (RenderSurface) Proxy.newProxyInstance(
+                            renderSurface.getClass().getClassLoader(),
+                            renderSurface.getClass().getInterfaces(),
+                            handler
+                    );
+                    renderSurfaceF.set(flutterView, proxy);
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}


### PR DESCRIPTION
fix #1960

### 分析
Flutter 3.19中`FlutterTextureView`在调用`detachFromRenderer`时，相比以前的版本，多了将`isPaused`设置为true的逻辑。导致页面回退，触发重新`attachToRenderer`时，调用其中的`startRenderingToSurface`方法走了`flutterJNI.onSurfaceWindowChanged(surface)`而不是原先的`flutterJNI.onSurfaceCreated(surface)`，导致页面不渲染。

### 解决方法
Flutter 3.19的`FlutterTextureView`中原先的`isAttachedToFlutterRenderer`变量没了，改为使用`flutterRenderer != null && !isPaused`联合判定的`shouldNotify`方法代替原来的逻辑。为了保护这部分逻辑，选择尽可能的在调用`startRenderingToSurface`前将`isPaused`重新设为false。因此采用动态代理的方式，拦截RenderSurface中的`attachToRenderer`接口调用，在调用前设置`isPaused`为false。（resume接口因为是内部调用，无法通过动态代理方式拦截）