### PR TITLE
[Android]fix SystemUiOverlayStyle设置失效

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/containers/ContainerThemeMgr.java
+++ b/android/src/main/java/com/idlefish/flutterboost/containers/ContainerThemeMgr.java
@@ -1,0 +1,52 @@
+package com.idlefish.flutterboost.containers;
+
+import com.idlefish.flutterboost.FlutterBoostUtils;
+
+import java.util.HashMap;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
+import io.flutter.embedding.engine.systemchannels.PlatformChannel;
+
+/**
+ * @author : Joe Chan
+ * @date : 2024/3/8 11:30
+ */
+public class ContainerThemeMgr {
+    private static final HashMap<Integer, PlatformChannel.SystemChromeStyle> themes =
+            new HashMap<>();
+    private static PlatformChannel.SystemChromeStyle finalStyle;
+
+    @UiThread
+    public static void onActivityPause(@NonNull FlutterBoostActivity activity, PlatformChannel.SystemChromeStyle restoreTheme) {
+        finalStyle = null;
+        if (activity.platformPlugin == null) {
+            return;
+        }
+        int hash = activity.hashCode();
+        PlatformChannel.SystemChromeStyle style =
+                FlutterBoostUtils.getCurrentSystemUiOverlayTheme(activity.platformPlugin, true);
+        PlatformChannel.SystemChromeStyle mergedStyle = FlutterBoostUtils.mergeSystemChromeStyle(restoreTheme, style);
+        if (mergedStyle != null) {
+            themes.put(hash, mergedStyle);
+        }
+    }
+
+    @UiThread
+    public static void onActivityDestroy(@NonNull FlutterBoostActivity activity) {
+        PlatformChannel.SystemChromeStyle style = themes.remove(activity.hashCode());
+        if (themes.isEmpty()) {
+            finalStyle = style;
+        }
+    }
+
+    @Nullable
+    public static PlatformChannel.SystemChromeStyle findTheme(@NonNull FlutterBoostActivity activity) {
+        return themes.get(activity.hashCode());
+    }
+
+    public static PlatformChannel.SystemChromeStyle getFinalStyle() {
+        return FlutterBoostUtils.copySystemChromeStyle(finalStyle);
+    }
+}

--- a/example/lib/case/system_ui_overlay_style.dart
+++ b/example/lib/case/system_ui_overlay_style.dart
@@ -30,7 +30,7 @@ class _SystemUiOverlayStyleDemoState extends State<SystemUiOverlayStyleDemo> {
   @override
   void initState() {
     super.initState();
-    _currentStyle = (widget.isDark ?? false)
+    _currentStyle = (widget.isDark ?? true)
         ? SystemUiOverlayStyle.dark
         : SystemUiOverlayStyle.light;
     withContainer = true;


### PR DESCRIPTION
### 相关issue

#1870 #1976 

### 问题分析

主要原因是Flutter层的`system_chrome.dart`的`setSystemUIOverlayStyle`方法中做了新老style的对比，只有发生变化的时候，才会调用Native方法进行设置，这就导致使用新Container模式打开Flutter页面，会因为上述原因，不会将新的Container的样式设置为Flutter层希望的，而是使用了Activity默认的。

所以解决的问题点就是在Native层，打开新容器时，将最新的样式设置给新容器。

### 解决思路

记录和维护一个Container-SystemUiOverlayStyle绑定关系的Map，当打开新容器时，将上个页面的Style拿出，设置给新容器即可。然后当容器销毁时，从Map中移除绑定关系。

有一个特殊的注意点，那就是从Flutter上设置SystemUiOverlayStyle，反馈到Native的方法中，只会对非null的值进行处理，也就意味着，这里实际上是有一个`在之前Style基础上，仅对非null参数做UI更新`的`隐性的merge`逻辑。一旦从Flutter层触发后，`platformPlugin`中的`currentTheme`其实就是一个不完整的Style，它内部仅仅只有最后一次更改的那几个参数，如果记录这个style，那么就会导致下次打开新容器时，样式又出现问题。所以代码逻辑中，在更新Map之前，Native需要有一个Merge Style的逻辑，保证持有的Style是完整的。

此外，当仅有的一个Flutter容器被销毁后，再打开新的，因为没有`上一个容器的Style`，所以不能还原。因此针对这种case，做特殊处理，将最后关闭的容器的Style记录下来。

### 测试

使用`system_ui_overlay_style.dart`进行测试。测试要点：1. 连续打开相同或不同Style的页面；2. 重复打开和关闭唯一的Flutter界面