### PR TITLE
fix-1863

### DIFF
--- a/example/lib/case/pushreplace.dart
+++ b/example/lib/case/pushreplace.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_boost/flutter_boost.dart';
+
+class PushReplacementWidget extends StatefulWidget {
+  final int index;
+
+  const PushReplacementWidget({Key? key, required this.index})
+      : super(key: key);
+
+  @override
+  State<PushReplacementWidget> createState() => _PushReplacementWidgetState();
+}
+
+class _PushReplacementWidgetState extends State<PushReplacementWidget> {
+  bool withContainer = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        // Here we take the value from the CounterPage object that was created by
+        // the App.build method, and use it to set our appbar title.
+        title: Text('PushReplaceDemo'),
+        actions: <Widget>[
+          Switch(
+            value: withContainer,
+            onChanged: (value) {
+              setState(() {
+                withContainer = value;
+              });
+            },
+            activeTrackColor: Colors.yellow,
+            activeColor: Colors.orangeAccent,
+          ),
+        ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'This is Page${widget.index}',
+              style: TextStyle(fontSize: 16, color: Colors.red),
+            ),
+            const SizedBox(height: 20),
+            OutlinedButton(
+              onPressed: () {
+                BoostNavigator.instance.pushReplacement(
+                  "pushReplacement",
+                  arguments: {
+                    'index': widget.index + 1,
+                  },
+                  withContainer: withContainer,
+                );
+              },
+              child: Text(
+                'PushAndReplace',
+                style: TextStyle(fontSize: 18, color: Colors.black),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/case/return_data.dart
+++ b/example/lib/case/return_data.dart
@@ -1,11 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_boost/flutter_boost.dart';
 
-class ReturnDataWidget extends StatelessWidget {
+class ReturnDataWidget extends StatefulWidget {
+  @override
+  State<ReturnDataWidget> createState() => _ReturnDataWidgetState();
+}
+
+class _ReturnDataWidgetState extends State<ReturnDataWidget> {
+  bool withContainer = true;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(title: const Text('Return data from a screen')),
+        appBar: AppBar(
+          title: const Text('Return data from a screen'),
+          actions: <Widget>[
+            Switch(
+              value: withContainer,
+              onChanged: (value) {
+                setState(() {
+                  withContainer = value;
+                });
+              },
+              activeTrackColor: Colors.yellow,
+              activeColor: Colors.orangeAccent,
+            ),
+          ],
+        ),
         body: Builder(builder: (BuildContext context) {
           return Center(
             child: ElevatedButton(
@@ -20,7 +41,7 @@ class ReturnDataWidget extends StatelessWidget {
 
   _navigateAndDisplaySelection(BuildContext context) async {
     final result = await BoostNavigator.instance
-        .push('selectionScreen', withContainer: true);
+        .push('selectionScreen', withContainer: withContainer);
     ScaffoldMessenger.of(context)
       ..removeCurrentSnackBar()
       ..showSnackBar(SnackBar(content: Text("$result")));

--- a/example/lib/flutter_page.dart
+++ b/example/lib/flutter_page.dart
@@ -389,6 +389,17 @@ class _FlutterIndexRouteState extends State<FlutterIndexRoute>
                   onTap: () => BoostNavigator.instance
                       .push("returnData", withContainer: withContainer)),
               InkWell(
+                  child: Container(
+                      padding: const EdgeInsets.all(8.0),
+                      margin: const EdgeInsets.all(8.0),
+                      color: Colors.yellow,
+                      child: const Text(
+                        'pushReplacement Demo',
+                        style: TextStyle(fontSize: 22.0, color: Colors.black),
+                      )),
+                  onTap: () => BoostNavigator.instance
+                      .push("pushReplacement", arguments: {'index': 1}, withContainer: withContainer)),
+              InkWell(
                 child: Container(
                     padding: const EdgeInsets.all(8.0),
                     margin: const EdgeInsets.all(8.0),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,6 +14,7 @@ import 'case/media_query.dart';
 import 'case/native_view_demo.dart';
 import 'case/platform_view_perf.dart';
 import 'case/popUntil.dart';
+import 'case/pushreplace.dart';
 import 'case/radial_hero_animation.dart';
 import 'case/return_data.dart';
 import 'case/rotation_transition.dart';
@@ -414,6 +415,14 @@ class _MyAppState extends State<MyApp> {
               uniqueId: uniqueId!,
               builder: (_) => const FlutterRebuildPageB(),
             );
+          });
+    },
+    'pushReplacement': (settings, uniqueId) {
+      return MaterialPageRoute(
+          settings: settings,
+          builder: (ctx) {
+            var m = settings.arguments as Map<dynamic, dynamic>?;
+            return PushReplacementWidget(index: m!['index'] ?? 1,);
           });
     },
   };

--- a/lib/src/boost_container.dart
+++ b/lib/src/boost_container.dart
@@ -125,7 +125,7 @@ class BoostContainerState extends State<BoostContainerWidget> {
 
   void _updatePagesList(BoostPage page, dynamic result) {
     assert(container.topPage == page);
-    container.removePageInternal(page, result: result);
+    container.removePage(page, result: result);
   }
 
   @override


### PR DESCRIPTION
issue的触发点仍然是如 #1863 中说的，是因为`entry.currentState`的状态不是`idle`而是`pushing`导致，至于`_debugLocked `的问题，是在pop因为currentState的原因出现异常后，再次进行pop时报出来的问题。

原先是对比纯Flutter项目后，将问题点集中在`entry.pageBased`上。现在去理解下`Navigator2.0`后，按照社区文档说明：
![image](https://github.com/alibaba/flutter_boost/assets/9456005/7015bcca-1924-4b48-bd6d-a49cec51664c)

结合上述现象，感觉是路由栈和pages不同步导致的问题。也就是说第一次pop时，从`Navigator._history`中取了route A进行pop，执行了`onPagePop`后，`BoostContainer`中的pages已经将当前Page移除了，但因为`currentState`的状态异常，导致Navigator的_history中没有移除，同时Navigator中的`pages`中也没有移除。所以下次pop时又取了出来，然后报错。

所以按照社区文档来说，只要通过`setState`进行同步就行了。因此直接使用`BoostContainer`的`notifyListeners`来触发`_onRouteChanged`监听进行`setState`即可。

另外example中补充pushReplace demo和完善returning data demo进行测试。