### PR TITLE
修复flutter侧和原生侧uniqueId不一致，导致FlutterA push FlutterB时.then监听结果，FlutterB…

### DIFF
--- a/ohos/flutter_boost/src/main/ets/components/containers/FlutterBoostEntry.ets
+++ b/ohos/flutter_boost/src/main/ets/components/containers/FlutterBoostEntry.ets
@@ -50,6 +50,9 @@ export default class FlutterBoostEntry extends FlutterEntry implements FlutterVi
 
     const uniqueId = util.generateRandomUUID(false);
     this.uniqueId = uniqueId;
+    if(params.uniqueId !=null && params.uniqueId !=''){
+      this.uniqueId = params.uniqueId;
+    }
     this.isAttached = false;
     this.isFirstAttached = true;
 

--- a/ohos/flutter_boost/src/main/ets/components/plugin/FlutterBoostPlugin.ets
+++ b/ohos/flutter_boost/src/main/ets/components/plugin/FlutterBoostPlugin.ets
@@ -119,6 +119,9 @@ export class FlutterBoostPlugin implements FlutterPlugin, MethodCallHandler, Nat
       if (params.opaque) {
         builder.setOpaque(params.opaque)
       }
+      if (params.uniqueId) {
+        builder.setUniqueId(params.uniqueId);
+      }
       builder.setRequestCode(this.requestCode)
       this.delegate.pushFlutterRoute(builder.build());
     } else {


### PR DESCRIPTION
修复flutter侧和原生侧uniqueId不一致，导致FlutterA push FlutterB时.then监听结果，FlutterB返回时回传参数 A收不到的问题