### PR TITLE
fix #1755 #1834

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FBPlatformViewsController.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FBPlatformViewsController.java
@@ -1,0 +1,109 @@
+package com.idlefish.flutterboost;
+
+import android.content.Context;
+import android.view.View;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.flutter.embedding.android.FlutterView;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorView;
+import io.flutter.plugin.platform.PlatformViewsController;
+import io.flutter.view.TextureRegistry;
+
+/**
+ *
+ * fix issues:
+ * <a href="https://github.com/alibaba/flutter_boost/issues/1755"/>
+ * <a href="https://github.com/alibaba/flutter_boost/issues/1834"/>
+ *
+ * @author : Joe Chan
+ * @date : 2024/5/22 13:35
+ */
+public class FBPlatformViewsController extends PlatformViewsController {
+
+    private Context appCtx;
+
+    /**
+     * 记录PlatformViewsController绑定使用的FlutterView
+     */
+    private FlutterView curFlutterView = null;
+
+    /**
+     * 占位FlutterView，用于防止不执行完整detach后，内部channelHandler继续响应时，出现空指针异常。
+     */
+    private FlutterView dummyFlutterView = null;
+
+    public FBPlatformViewsController() {
+        super();
+    }
+
+    @Override
+    public void attach(@Nullable Context context, @NonNull TextureRegistry textureRegistry,
+                       @NonNull DartExecutor dartExecutor) {
+        if (appCtx == null && context != null) {
+            appCtx = context.getApplicationContext();
+            dummyFlutterView = new FlutterView(appCtx);
+        }
+        super.attach(context, textureRegistry, dartExecutor);
+    }
+
+    @Override
+    public void detach() {
+        // 不执行完整的detach，这样就使内部channelHandler正确响应，同时避免platformView触摸事件无法响应
+        // super.detach();
+        // 使用反射将内部context变量设置为null，一方面解决重新attach时的异常，另一方面解决内存泄漏
+        try {
+            Field contextF = getClass().getSuperclass().getDeclaredField("context");
+            contextF.setAccessible(true);
+            contextF.set(this, null);
+        } catch (Exception ignore) {
+        }
+        destroyOverlaySurfaces();
+    }
+
+    @Override
+    public void attachToView(@NonNull FlutterView newFlutterView) {
+        if (curFlutterView == null) {
+            super.attachToView(newFlutterView);
+            curFlutterView = newFlutterView;
+        } else if (newFlutterView != curFlutterView) {
+            removePlatformWrapperOrParents();
+            super.attachToView(newFlutterView);
+            curFlutterView = newFlutterView;
+        }
+    }
+
+
+    @Override
+    public void detachFromView() {
+        if (curFlutterView != null) {
+            super.detachFromView();
+            curFlutterView = null;
+            //将占位FlutterView绑定上去
+            attachToView(dummyFlutterView);
+        }
+    }
+
+    public void removePlatformWrapperOrParents() {
+        if (curFlutterView != null) {
+            List<View> needRemoveViews = new ArrayList<>();
+            int childCount = curFlutterView.getChildCount();
+            for (int i = 0; i < childCount; i++) {
+                View view = curFlutterView.getChildAt(i);
+                if (view.getClass().getName().contains("PlatformViewWrapper") || view instanceof FlutterMutatorView) {
+                    needRemoveViews.add(view);
+                }
+            }
+            if (!needRemoveViews.isEmpty()) {
+                for (View needRemoveView : needRemoveViews) {
+                    curFlutterView.removeView(needRemoveView);
+                }
+            }
+        }
+    }
+}

--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
@@ -18,7 +18,9 @@ import java.util.Map;
 import io.flutter.embedding.android.FlutterEngineProvider;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
+import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.view.FlutterMain;
 
 public class FlutterBoost {
@@ -75,7 +77,7 @@ public class FlutterBoost {
             if (engine == null) {
                 // Second, when the engine from option.flutterEngineProvider is null,
                 // we should create a new engine
-                engine = new FlutterEngine(application, options.shellArgs());
+                engine = new FlutterEngine(application, null, null, new FBPlatformViewsController(), options.shellArgs(), true);
             }
 
             // Cache the created FlutterEngine in the FlutterEngineCache.

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -68,6 +68,17 @@
         </activity>
 
         <activity
+            android:name=".tab.TabPlatformViewActivity"
+            android:exported="true"
+            android:theme="@style/Theme.AppCompat"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize" >
+            <meta-data android:name="io.flutter.embedding.android.SplashScreenDrawable" android:resource="@drawable/launch_background"/>
+
+        </activity>
+
+        <activity
             android:name=".tab.TabCustomViewActivity"
             android:exported="true"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/MainActivity.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/MainActivity.java
@@ -2,21 +2,18 @@ package com.idlefish.flutterboost.example;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-
-import com.idlefish.flutterboost.FlutterBoost;
 import com.idlefish.flutterboost.containers.FlutterBoostActivity;
 
-import java.lang.ref.WeakReference;
 import java.util.HashMap;
 import java.util.Map;
-import android.util.Log;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs;
 
 import static com.idlefish.flutterboost.containers.FlutterActivityLaunchConfigs.ACTIVITY_RESULT_KEY;
@@ -27,6 +24,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private TextView mOpenNative;
     private TextView mOpenFlutter;
     private TextView mOpenFlutterFragment;
+    private TextView mOpenFlutterPlatformViewFragment;
     private TextView mOpenCustomViewTab;
 
     @Override
@@ -43,11 +41,13 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         mOpenNative = findViewById(R.id.open_native);
         mOpenFlutter = findViewById(R.id.open_flutter);
         mOpenFlutterFragment = findViewById(R.id.open_flutter_fragment);
+        mOpenFlutterPlatformViewFragment = findViewById(R.id.open_flutter_platformview_fragment);
         mOpenCustomViewTab = findViewById(R.id.open_custom_view_tab);
 
         mOpenNative.setOnClickListener(this);
         mOpenFlutter.setOnClickListener(this);
         mOpenFlutterFragment.setOnClickListener(this);
+        mOpenFlutterPlatformViewFragment.setOnClickListener(this);
         mOpenCustomViewTab.setOnClickListener(this);
     }
 
@@ -75,6 +75,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             startActivityForResult(intent, REQUEST_CODE);
         } else if (v == mOpenFlutterFragment) {
             NativeRouter.openPageByUrl(this, NativeRouter.FLUTTER_FRAGMENT_PAGE_URL,params);
+        } else if (v == mOpenFlutterPlatformViewFragment) {
+            NativeRouter.openPageByUrl(this, NativeRouter.FLUTTER_PLATFORMVIEW_FRAGMENT_PAGE_URL,params);
         } else if (v == mOpenCustomViewTab) {
             NativeRouter.openPageByUrl(this, NativeRouter.FLUTTER_CUSTOM_VIEW_URL, params);
         }

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/NativePageActivity.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/NativePageActivity.java
@@ -6,15 +6,14 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.TextView;
 
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-
 import com.idlefish.flutterboost.containers.FlutterBoostActivity;
 
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs;
 
 
@@ -23,6 +22,8 @@ public class NativePageActivity extends AppCompatActivity implements View.OnClic
     private TextView mOpenNative;
     private TextView mOpenFlutter;
     private TextView mOpenFlutterFragment;
+
+    private TextView mOpenFlutterPlatformViewFragment;
 
     @Override
     protected void onResume() {
@@ -37,9 +38,13 @@ public class NativePageActivity extends AppCompatActivity implements View.OnClic
 
         mOpenNative = findViewById(R.id.open_native);
         mOpenFlutter = findViewById(R.id.open_flutter);
+        mOpenFlutterFragment = findViewById(R.id.open_flutter_fragment);
+        mOpenFlutterPlatformViewFragment = findViewById(R.id.open_flutter_platformview_fragment);
 
         mOpenNative.setOnClickListener(this);
         mOpenFlutter.setOnClickListener(this);
+        mOpenFlutterFragment.setOnClickListener(this);
+        mOpenFlutterPlatformViewFragment.setOnClickListener(this);
     }
 
     @Override
@@ -61,6 +66,8 @@ public class NativePageActivity extends AppCompatActivity implements View.OnClic
             startActivity(intent);
         } else if (v == mOpenFlutterFragment) {
             NativeRouter.openPageByUrl(this, NativeRouter.FLUTTER_FRAGMENT_PAGE_URL,params);
+        } else if (v == mOpenFlutterPlatformViewFragment) {
+            NativeRouter.openPageByUrl(this, NativeRouter.FLUTTER_PLATFORMVIEW_FRAGMENT_PAGE_URL,params);
         }
     }
 

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/NativeRouter.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/NativeRouter.java
@@ -5,9 +5,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
-
 import com.idlefish.flutterboost.example.tab.TabCustomViewActivity;
 import com.idlefish.flutterboost.example.tab.TabMainActivity;
+import com.idlefish.flutterboost.example.tab.TabPlatformViewActivity;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +29,8 @@ public class NativeRouter {
     public static final String NATIVE_PAGE_URL = "sample://nativePage";
     public static final String FLUTTER_PAGE_URL = "sample://flutterPage";
     public static final String FLUTTER_FRAGMENT_PAGE_URL = "sample://flutterFragmentPage";
+    public static final String FLUTTER_PLATFORMVIEW_FRAGMENT_PAGE_URL = "sample" +
+            "://flutterPlatformViewFragmentPage";
     public static final String FLUTTER_CUSTOM_VIEW_URL = "sample://FlutterCustomView";
 
     public static boolean openPageByUrl(Context context, String url, Map params) {
@@ -39,27 +41,30 @@ public class NativeRouter {
 
         String path = url.split("\\?")[0];
 
-        Log.i("openPageByUrl",path);
+        Log.i("openPageByUrl", path);
 
         try {
             if (pageName.containsKey(path)) {
-                Intent intent =FlutterActivity.createDefaultIntent(context);
-                if(context instanceof Activity){
-                    Activity activity=(Activity)context;
-                    activity.startActivityForResult(intent,requestCode);
-                }else{
+                Intent intent = FlutterActivity.createDefaultIntent(context);
+                if (context instanceof Activity) {
+                    Activity activity = (Activity) context;
+                    activity.startActivityForResult(intent, requestCode);
+                } else {
                     context.startActivity(intent);
                 }
                 return true;
             } else if (url.startsWith(FLUTTER_FRAGMENT_PAGE_URL)) {
                 context.startActivity(new Intent(context, TabMainActivity.class));
                 return true;
+            } else if (url.startsWith(FLUTTER_PLATFORMVIEW_FRAGMENT_PAGE_URL)) {
+                context.startActivity(new Intent(context, TabPlatformViewActivity.class));
+                return true;
             } else if (url.startsWith(NATIVE_PAGE_URL)) {
                 context.startActivity(new Intent(context, NativePageActivity.class));
                 return true;
             } else if (url.startsWith(FLUTTER_CUSTOM_VIEW_URL)) {
                 context.startActivity(new Intent(context, TabCustomViewActivity.class));
-                return  true;
+                return true;
             }
 
             return false;

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/RunBall.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/RunBall.java
@@ -6,7 +6,6 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Point;
-import androidx.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.animation.LinearInterpolator;
@@ -14,6 +13,8 @@ import android.view.animation.LinearInterpolator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+
+import androidx.annotation.Nullable;
 
 public class RunBall extends View {
     private ValueAnimator mAnimator;//时间流
@@ -196,5 +197,11 @@ public class RunBall extends View {
         int g = 30 + random.nextInt(200);
         int b = 30 + random.nextInt(200);
         return Color.rgb( r, g, b);
+    }
+
+    public void destroy() {
+        if (mAnimator.isRunning()) {
+            mAnimator.cancel();
+        }
     }
 }

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/RunBallView.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/RunBallView.java
@@ -28,5 +28,6 @@ class RunBallView implements PlatformView {
 
     @Override
     public void dispose() {
+       view.destroy();
     }
 }

--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/tab/TabPlatformViewActivity.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/tab/TabPlatformViewActivity.java
@@ -1,0 +1,135 @@
+package com.idlefish.flutterboost.example.tab;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+
+import com.idlefish.flutterboost.containers.FlutterBoostFragment;
+import com.idlefish.flutterboost.example.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentTransaction;
+
+public class TabPlatformViewActivity extends FragmentActivity implements View.OnClickListener {
+    private LinearLayout tab1;
+    private LinearLayout tab2;
+
+    private ImageView tab1Img;
+    private ImageView tab2Img;
+
+    private MsgFlutterFragment tab1Fragment;
+    private FriendFlutterFragment tab2Fragment;
+
+    private List<Fragment> fragmentList;
+    Fragment currentFragment;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.tab_platformview_page);
+
+        init();
+        initClick();
+        //默认选中第1个
+        setSelect(0);
+    }
+
+
+    @Override
+    public void onBackPressed() {
+        if (currentFragment instanceof FlutterBoostFragment) {
+            ((FlutterBoostFragment)currentFragment).onBackPressed();
+        } else {
+            finish();
+        }
+    }
+
+    //初始化元素
+    private void init() {
+        tab1 = (LinearLayout) findViewById(R.id.platform1Tab);
+        tab2 = (LinearLayout) findViewById(R.id.platform2Tab);
+
+        tab1Img = (ImageView) findViewById(R.id.tab1_img);
+        tab2Img = (ImageView) findViewById(R.id.tab2_img);
+
+
+        fragmentList = new ArrayList<>();
+        tab1Fragment = new MsgFlutterFragment
+                .CachedEngineFragmentBuilder(MsgFlutterFragment.class)
+                .url("platformview/listview")
+                .build();
+
+        tab2Fragment = new FriendFlutterFragment
+                .CachedEngineFragmentBuilder(FriendFlutterFragment.class)
+                .url("platformview/animation")
+                .build();
+    }
+
+    //初始化监听
+    private void initClick() {
+        tab1.setOnClickListener(this);
+        tab2.setOnClickListener(this);
+    }
+
+    private void showFragment(Fragment fragment) {
+        FragmentManager fm = getSupportFragmentManager();
+        if (currentFragment != fragment) {
+            // 判断传入的fragment是不是当前的currentFragment
+            FragmentTransaction transaction = fm.beginTransaction();
+            if (currentFragment != null) {
+                // 不是则隐藏
+                transaction.hide(currentFragment);
+            }
+            // 然后将传入的fragment赋值给currentFragment
+            currentFragment = fragment;
+
+            // 判断传入的fragment是否已经被add()过
+            if (!fragment.isAdded()) {
+                transaction.add(R.id.fragment_stub, fragment).show(fragment).commit();
+            } else {
+                transaction.show(fragment).commit();
+            }
+        }
+    }
+
+    @Override
+    public void onClick(View view) {
+        resetImages();
+        switch (view.getId()) {
+            case R.id.platform1Tab:
+                setSelect(0);
+                break;
+            case R.id.platform2Tab:
+                setSelect(1);
+                break;
+        }
+
+    }
+
+    //全部图片设为暗色
+    private void resetImages() {
+        tab1Img.setImageResource(android.R.drawable.checkbox_off_background);
+        tab2Img.setImageResource(android.R.drawable.checkbox_off_background);
+    }
+
+    //点亮选中图片
+    private void setSelect(int i) {
+        resetImages();
+        switch (i) {
+            case 0:
+                tab1Img.setImageResource(android.R.drawable.checkbox_on_background);
+                showFragment(tab1Fragment);
+                break;
+            case 1:
+                tab2Img.setImageResource(android.R.drawable.checkbox_on_background);
+                showFragment(tab2Fragment);
+                break;
+        }
+    }
+}

--- a/example/android/app/src/main/res/layout/native_page.xml
+++ b/example/android/app/src/main/res/layout/native_page.xml
@@ -2,73 +2,88 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
+    android:background="@android:color/white"
     android:gravity="left"
-    android:background="@android:color/white">
+    android:orientation="vertical">
 
     <TextView
+        android:id="@+id/info"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
         android:layout_marginTop="80dp"
-        android:id="@+id/info"
         android:text="@string/native_info"
         android:textColor="@android:color/holo_blue_dark"
-        android:textSize="28sp"
-        android:layout_gravity="center_horizontal"/>
+        android:textSize="28sp" />
 
-    <View android:layout_width="1dp"
+    <View
+        android:layout_width="1dp"
         android:layout_height="0dp"
-        android:layout_weight="1"/>
+        android:layout_weight="1" />
 
     <TextView
-        android:background="@android:color/holo_orange_dark"
-        android:layout_margin="8.0dp"
-        android:padding="8.0dp"
-        android:textColor="@android:color/black"
         android:id="@+id/open_native"
-        android:textAllCaps="false"
-        android:textSize="16sp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/open_native" />
+        android:layout_margin="8.0dp"
+        android:background="@android:color/holo_orange_dark"
+        android:padding="8.0dp"
+        android:text="@string/open_native"
+        android:textAllCaps="false"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
 
     <TextView
-        android:background="@android:color/holo_orange_dark"
-        android:layout_margin="8.0dp"
-        android:padding="8.0dp"
-        android:textColor="@android:color/black"
         android:id="@+id/open_flutter"
-        android:textAllCaps="false"
-        android:textSize="16sp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/open_flutter" />
-
-    <TextView
-        android:background="@android:color/holo_orange_dark"
         android:layout_margin="8.0dp"
+        android:background="@android:color/holo_orange_dark"
         android:padding="8.0dp"
-        android:textColor="@android:color/black"
-        android:id="@+id/open_custom_view_tab"
+        android:text="@string/open_flutter"
         android:textAllCaps="false"
-        android:textSize="16sp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/open_custom_view_tab" />
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
 
     <TextView
+        android:id="@+id/open_custom_view_tab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8.0dp"
         android:background="@android:color/holo_orange_dark"
+        android:padding="8.0dp"
+        android:text="@string/open_custom_view_tab"
+        android:textAllCaps="false"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/open_flutter_fragment"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="8.0dp"
+        android:layout_marginTop="8.0dp"
+        android:layout_marginRight="8.0dp"
+        android:layout_marginBottom="8.0dp"
+        android:background="@android:color/holo_orange_dark"
+        android:padding="8.0dp"
+        android:text="@string/open_flutter_fragment"
+        android:textAllCaps="false"
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/open_flutter_platformview_fragment"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginLeft="8.0dp"
         android:layout_marginTop="8.0dp"
         android:layout_marginRight="8.0dp"
         android:layout_marginBottom="80.0dp"
+        android:background="@android:color/holo_orange_dark"
         android:padding="8.0dp"
-        android:textColor="@android:color/black"
-        android:id="@+id/open_flutter_fragment"
+        android:text="@string/open_flutter_platformview_fragment"
         android:textAllCaps="false"
-        android:textSize="16sp"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/open_flutter_fragment" />
-
+        android:textColor="@android:color/black"
+        android:textSize="16sp" />
 </LinearLayout>

--- a/example/android/app/src/main/res/layout/tab_platformview_page.xml
+++ b/example/android/app/src/main/res/layout/tab_platformview_page.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/white"
+    android:orientation="vertical">
+
+    <com.idlefish.flutterboost.example.FitSystemWindowFrameLayout
+        android:id="@+id/fragment_stub"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:background="#000000"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:id="@+id/platform1Tab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <ImageView
+                android:id="@+id/tab1_img"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:src="@android:drawable/checkbox_off_background" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="platformView1"
+                android:textColor="#ffffffff" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/platform2Tab"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <ImageView
+                android:id="@+id/tab2_img"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:src="@android:drawable/checkbox_off_background" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="platformView2"
+                android:textColor="#ffffffff" />
+        </LinearLayout>
+
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/example/android/app/src/main/res/values/strings.xml
+++ b/example/android/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="open_native">open native page</string>
     <string name="open_flutter">open flutter page</string>
     <string name="open_flutter_fragment">open flutter fragment page</string>
+    <string name="open_flutter_platformview_fragment">open flutter platformview fragment page</string>
     <string name="open_custom_view_tab">open custom view page</string>
     <string name="native_info">This is a native activity</string>
     <string name="flutter1">Flutter1</string>


### PR DESCRIPTION
fix #1755 和 #1834，修复`example`中`RunBallView`的内存泄漏，增加PlatformView在多Tab下的测试用例。

继承`PlatformViewController`重写一些方法，在`attachToView`中记录最新`FlutterView`，并用于判断是否切换`FlutterView`，然后在切换前，从原先的`FlutterView`上移除`PlatfromView`，解决PlatfromView已有parent的问题。

重写`detach`方法，不去清空原先`PlatformViewController`内部的`channelHandler`，使其在最后一个Flutter界面退出后，仍然能够响应PlatformView的`dispose`方法，解决PlatformView的内存泄漏问题。

测试Flutter SDK: 3.16.5 和 3.19.5。