### PR TITLE
[ohos] 允许业务自己实现页面出栈逻辑

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 1. [ohos]解决应用切换横屏时自动分屏的问题
 2. [ohos]解决dialog透明弹窗从全屏页面返回时重新执行进入动画的问题
 3. [ohos,dart]native侧取消业务自定义实现RouterOptions，优化页面返回传参接口易用性，修复native页面返回flutter页面时传参可能失败的问题
+4. [ohos] 允许业务自己实现页面出栈逻辑
 
 ## 4.5.11
 1. [dart]添加`SystemChrome.setPreferredOrientations`测试案例

--- a/example/ohos/entry/src/main/ets/entryability/EntryAbility.ets
+++ b/example/ohos/entry/src/main/ets/entryability/EntryAbility.ets
@@ -57,6 +57,11 @@ export default class EntryAbility extends UIAbility implements FlutterBoostDeleg
     RouterModule.push(routerName, options, onPageResult);
   }
 
+  // 关闭flutter页面
+  popRoute(options: FlutterBoostRouteOptions): boolean {
+    return false;
+  }
+
   async onCreate(want: Want, launchParam: AbilityConstant.LaunchParam) {
     hilog.info(0x0000, TAG, '%{public}s', 'Ability onCreate');
     FlutterManager.getInstance().pushUIAbility(this)

--- a/example/ohos/entry/src/main/ets/pages/FlutterUIComponent.ets
+++ b/example/ohos/entry/src/main/ets/pages/FlutterUIComponent.ets
@@ -15,10 +15,12 @@ export struct FlutterUIComponent {
     TransitionEffect.OPACITY
       .combine(TransitionEffect.move(TransitionEdge.END)).animation({curve: Curves.springMotion()});
 
-  aboutToAppear() {
+  async aboutToAppear() {
     hilog.info(0x0000, TAG, 'Component(#%{public}s) aboutToAppear===', this.routerOptions!.getPageName());
-    this.flutterEntry = new FlutterBoostEntry(getContext(this), this.routerOptions);
-    this.flutterEntry.aboutToAppear();
+    this.flutterEntry = new FlutterBoostEntry(getContext(this), this.routerOptions, false, () => {
+      // Do nothing: The top-level tab page does not respond to the back gesture.
+    });
+    await this.flutterEntry.aboutToAppear();
     // The |aboutToAppear| method is called first,
     // followed by the |getFlutterView| method.
     this.flutterView = this.flutterEntry.getFlutterView();

--- a/example/ohos/entry/src/main/ets/pages/FlutterUIDialog.ets
+++ b/example/ohos/entry/src/main/ets/pages/FlutterUIDialog.ets
@@ -39,10 +39,10 @@ export struct FlutterUIDialog {
       .combine(TransitionEffect.move(TransitionEdge.BOTTOM)).animation({curve: Curves.springMotion()});
   @State enableAnimation: boolean = true;
 
-  aboutToAppear() {
+  async aboutToAppear() {
     hilog.info(0x0000, TAG, "aboutToAppear===");
     this.flutterEntry = new FlutterBoostEntry(getContext(this), this.routerOptions, /*isDialog*/true);
-    this.flutterEntry.aboutToAppear();
+    await this.flutterEntry.aboutToAppear();
     // The |aboutToAppear| method is called first,
     // followed by the |getFlutterView| method.
     this.flutterView = this.flutterEntry.getFlutterView();

--- a/example/ohos/entry/src/main/ets/pages/FlutterUIPage.ets
+++ b/example/ohos/entry/src/main/ets/pages/FlutterUIPage.ets
@@ -31,13 +31,19 @@ const TAG: string = "FlutterUIPage";
 export struct FlutterUIPage {
   private flutterEntry: FlutterBoostEntry | null = null;
   private flutterView: FlutterView | null = null;
+  private routeStack: NavPathStack | null = null;
   @Prop xComponentType: XComponentType = XComponentType.SURFACE;
   @Prop routerOptions: FlutterBoostRouteOptions;
 
-  aboutToAppear() {
+  onPopCallback(result: Record<string, Object>): void {
+    hilog.info(0x0000, TAG, "onPopCallback===");
+    this.routeStack?.pop(result);
+  }
+
+  async aboutToAppear() {
     hilog.info(0x0000, TAG, "aboutToAppear===");
-    this.flutterEntry = new FlutterBoostEntry(getContext(this), this.routerOptions);
-    this.flutterEntry.aboutToAppear();
+    this.flutterEntry = new FlutterBoostEntry(getContext(this), this.routerOptions, false, this.onPopCallback);
+    await this.flutterEntry.aboutToAppear();
     // The |aboutToAppear| method is called first,
     // followed by the |getFlutterView| method.
     this.flutterView = this.flutterEntry.getFlutterView();
@@ -77,6 +83,7 @@ export struct FlutterUIPage {
     .onReady((ctx: NavDestinationContext) => {
       try {
         hilog.info(0x0000, TAG, "onReady===");
+        this.routeStack = ctx.pathStack;
         this.flutterEntry?.onReady(ctx.pathStack);
       } catch (e) {
         hilog.error(0x0000, TAG, `onReady catch exception: ${JSON.stringify(e)}`);

--- a/ohos/src/main/ets/components/FlutterBoostDelegate.ets
+++ b/ohos/src/main/ets/components/FlutterBoostDelegate.ets
@@ -29,5 +29,5 @@ import FlutterBoostRouteOptions from './FlutterBoostRouteOptions';
 export default interface FlutterBoostDelegate {
   pushNativeRoute(options: FlutterBoostRouteOptions, onPageResult?: (pageName: string, result: Record<string, Object>) => void): void;
   pushFlutterRoute(options: FlutterBoostRouteOptions, onPageResult?: (pageName: string, result: Record<string, Object>) => void): void;
-  //TODO:是不是得加一个pop？
+  popRoute(options: FlutterBoostRouteOptions): boolean;
 }

--- a/ohos/src/main/ets/components/containers/FlutterBoostEntry.ets
+++ b/ohos/src/main/ets/components/containers/FlutterBoostEntry.ets
@@ -45,14 +45,16 @@ export default class FlutterBoostEntry extends FlutterEntry implements FlutterVi
   private isDialogMode: boolean;
   private routeStack: NavPathStack | null = null;
   private isStackPopping: boolean = false
+  private onPopCallback?: (result: Record<string, Object>) => void;
 
-  constructor(context: Context, routerOptions: FlutterBoostRouteOptions, isDialog: boolean = false) {
+  constructor(context: Context, routerOptions: FlutterBoostRouteOptions, isDialog?: boolean, onPop?: (result: Record<string, Object>) => void) {
     super(context);
 
     this.thisContext = context;
 
     this.routerOptions = routerOptions;
-    this.isDialogMode = isDialog;
+    this.isDialogMode = isDialog ?? false;
+    this.onPopCallback = onPop;
 
     if (this.routerOptions && this.routerOptions.getUniqueId()) {
       //1、 当路由参数中的uniqueId不为null的时候，说明uniqueId已经由dart侧确定，因此直接获取
@@ -123,9 +125,13 @@ export default class FlutterBoostEntry extends FlutterEntry implements FlutterVi
   finishContainer(result: Record<string, Object>) {
     if (this.isTraceEnabled()) Log.d(TAG, "#finishContainer: " + this.getUrl());
     if (this.stage !== LifecycleStage.ON_FINISH) {
-      this.routeStack ? this.routeStack.pop(result) : router.back();
-      this.stage = LifecycleStage.ON_FINISH;
+      if (this.onPopCallback) {
+        this.onPopCallback(result);
+      } else {
+        this.routeStack ? this.routeStack.pop(result) : router.back();
+      }
       this.isStackPopping = true;
+      this.stage = LifecycleStage.ON_FINISH;
     } else {
       Log.e(TAG, 'finishContainer can not called twice!');
     }

--- a/ohos/src/main/ets/components/plugin/FlutterBoostPlugin.ets
+++ b/ohos/src/main/ets/components/plugin/FlutterBoostPlugin.ets
@@ -39,7 +39,7 @@ import FlutterBoostDelegate from '../FlutterBoostDelegate';
 import CommonParams from '../messages/CommonParams';
 import Log from '../util/Log'
 import StackInfo from '../messages/StackInfo';
-import { FlutterBoostRouteOptionsBuilder } from '../FlutterBoostRouteOptions';
+import FlutterBoostRouteOptions, { FlutterBoostRouteOptionsBuilder } from '../FlutterBoostRouteOptions';
 import EventListener from '../util/EventListener';
 import ListenerRemover from '../util/ListenerRemover';
 import FlutterBoostUtils from '../FlutterBoostUtils';
@@ -97,6 +97,7 @@ export class FlutterBoostPlugin implements FlutterPlugin, MethodCallHandler, Nat
 
   // NativeRouterApi override ==> start
   onPushNativeRoute(params: CommonParams) {
+    if (this.isTraceEnabled()) Log.i(TAG, `#onPushNativeRoute: ${JSON.stringify(params)}`);
     if (this.delegate) {
       const builder = new FlutterBoostRouteOptionsBuilder()
       if (params.pageName) {
@@ -114,7 +115,7 @@ export class FlutterBoostPlugin implements FlutterPlugin, MethodCallHandler, Nat
   }
 
   onPushFlutterRoute(params: CommonParams) {
-    if (this.isTraceEnabled()) Log.i(TAG, "#onPushFlutterRoute: " + params.pageName);
+    if (this.isTraceEnabled()) Log.i(TAG, `#onPushFlutterRoute: ${JSON.stringify(params)}`);
     if (this.delegate) {
       const builder = new FlutterBoostRouteOptionsBuilder()
       if (params.pageName) {
@@ -136,18 +137,32 @@ export class FlutterBoostPlugin implements FlutterPlugin, MethodCallHandler, Nat
   }
 
   onPopRoute(params: CommonParams, completion: () => void) {
-    const uniqueId = params.uniqueId
-    if (this.isTraceEnabled()) Log.i(TAG, "#onPopRoute: " + uniqueId);
-    if (uniqueId && uniqueId.length > 0) {
-      const container = FlutterContainerManager.getInstance().findContainerById(uniqueId);
-      if (container) {
-        container.finishContainer(params.arguments ? params.arguments : {})
+    if (this.isTraceEnabled()) Log.i(TAG, `#onPopRoute: ${JSON.stringify(params)}`);
+    if (this.delegate) {
+      const options: FlutterBoostRouteOptions = new FlutterBoostRouteOptionsBuilder()
+                                                  .setPageName(params.pageName ?? '')
+                                                  .setUniqueId(params.uniqueId!)
+                                                  .setArguments(params.arguments ?? {})
+                                                  .build();
+      let isHandled: boolean = this.delegate.popRoute(options);
+      if (isHandled) {
         completion();
       } else {
-        throw new Error("Oops!! Can not find the page. uniqueId:" + uniqueId);
+        const uniqueId = params.uniqueId;
+        if (uniqueId) {
+          const container = FlutterContainerManager.getInstance().findContainerById(uniqueId);
+          if (container) {
+            container.finishContainer(params.arguments ? params.arguments : {})
+            completion();
+          } else {
+            throw new Error("Oops!! Can not find the page. uniqueId:" + uniqueId);
+          }
+        } else {
+          throw new Error(`Oops!! The unique id is invalid: ${uniqueId}`);
+        }
       }
     } else {
-      throw new Error("Oops!! The unique id is undefined!");
+      throw new Error("FlutterBoostPlugin might *NOT* set delegate!");
     }
   }
 


### PR DESCRIPTION
这里提供了两种方式：
1. 在FlutterBoostDelegate中提供popRoute接口：业务自己处理页面出栈逻辑，则返回`true`;
2. 在FlutterBoostEntry的构造函数中提供可选的onPop回调接口，如果该参数不为空，则执行该回调逻辑；