### PR TITLE
add null check

### DIFF
--- a/lib/src/boost_navigator.dart
+++ b/lib/src/boost_navigator.dart
@@ -117,6 +117,7 @@ class BoostNavigator {
   Future<void> popUntil({String? route, String? uniqueId}) async {
     assert(
         appState != null, 'Please check if the engine has been initialized!');
+    assert(route != null || uniqueId != null, 'Please specify either "route" or "uniqueId"!');
     return appState!.popUntil(route: route, uniqueId: uniqueId);
   }
 

--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -459,7 +459,11 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
                 ?.popUntil(_withPage(targetPage!)));
       }
     } else {
-      topContainer?.navigator?.popUntil(_withPage(targetPage!));
+      if (targetPage != null) {
+        topContainer?.navigator?.popUntil(_withPage(targetPage));
+      } else {
+        Logger.error('can\'t find route=$route, uniqueId=$uniqueId on popUntil');
+      }
     }
   }
 


### PR DESCRIPTION
对`popUtil`方法中最后的`targetPage`进行判空。

related issue: #2141 #2129 