### PR TITLE
[Android]更新使用示例，修复bug

### DIFF
--- a/example/android/app/src/main/java/com/idlefish/flutterboost/example/MyFlutterBoostDelegate.java
+++ b/example/android/app/src/main/java/com/idlefish/flutterboost/example/MyFlutterBoostDelegate.java
@@ -1,5 +1,6 @@
 package com.idlefish.flutterboost.example;
 
+import android.content.Context;
 import android.content.Intent;
 import android.widget.Toast;
 
@@ -7,36 +8,68 @@ import com.idlefish.flutterboost.FlutterBoost;
 import com.idlefish.flutterboost.FlutterBoostDelegate;
 import com.idlefish.flutterboost.FlutterBoostRouteOptions;
 import com.idlefish.flutterboost.containers.FlutterBoostActivity;
+import com.idlefish.flutterboost.containers.FlutterViewContainer;
 
+import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
+import io.flutter.embedding.android.FlutterFragment;
 
 public class MyFlutterBoostDelegate implements FlutterBoostDelegate {
 
+    private Context getCurrentContext() {
+        FlutterViewContainer topContainer = FlutterBoost.instance().getTopContainer();
+        Context context = null;
+        if (topContainer != null) {
+            context = topContainer.getContextActivity();
+        }
+        if (context == null) {
+            context = FlutterBoost.instance().currentActivity();
+        }
+        return context;
+    }
+
+    private void startActivityForResult(Intent intent, int requestCode) {
+        FlutterViewContainer topContainer = FlutterBoost.instance().getTopContainer();
+        if (topContainer instanceof FlutterFragment) {
+            //如果是从FlutterBoostFragment唤起的新页面，只有使用FlutterFragment进行start，才能收到result
+            ((FlutterFragment) topContainer).startActivityForResult(intent, requestCode);
+        } else if (topContainer instanceof FlutterActivity) {
+            ((FlutterActivity) topContainer).startActivityForResult(intent, requestCode);
+        } else {
+            FlutterBoost.instance().currentActivity().startActivityForResult(intent,
+                    requestCode);
+        }
+    }
+
     @Override
     public void pushNativeRoute(FlutterBoostRouteOptions options) {
-        Intent intent = new Intent(FlutterBoost.instance().currentActivity(), NativePageActivity.class);
-        FlutterBoost.instance().currentActivity().startActivityForResult(intent, options.requestCode());
+        Context context = getCurrentContext();
+        Intent intent = new Intent(context, NativePageActivity.class);
+        startActivityForResult(intent, options.requestCode());
     }
 
     @Override
     public void pushFlutterRoute(FlutterBoostRouteOptions options) {
-        Class<? extends FlutterBoostActivity> activityClass = options.opaque() ? FlutterBoostActivity.class : TransparencyPageActivity.class;
+        Class<? extends FlutterBoostActivity> activityClass = options.opaque() ?
+                FlutterBoostActivity.class : TransparencyPageActivity.class;
         Intent intent = new FlutterBoostActivity.CachedEngineIntentBuilder(activityClass)
                 .destroyEngineWithActivity(false)
                 // 注意：这里需要回传dart带过来的uniqueId，否则页面退出时传参可能失败。
                 // 但，如果是从Native打开Flutter页面，请不要给uniqueId赋*任何值*！！！
                 .uniqueId(options.uniqueId())
-                .backgroundMode(options.opaque() ? BackgroundMode.opaque : BackgroundMode.transparent)
+                .backgroundMode(options.opaque() ? BackgroundMode.opaque :
+                        BackgroundMode.transparent)
                 .url(options.pageName())
                 .urlParams(options.arguments())
-                .build(FlutterBoost.instance().currentActivity());
-        FlutterBoost.instance().currentActivity().startActivity(intent);
+                .build(getCurrentContext());
+        startActivityForResult(intent, options.requestCode());
     }
 
     @Override
     public boolean popRoute(FlutterBoostRouteOptions options) {
         //自定义popRoute处理逻辑,如果不想走默认处理逻辑返回true进行拦截
-        Toast.makeText(FlutterBoost.instance().currentActivity().getApplicationContext(), "Add customized popRoute handler here", Toast.LENGTH_SHORT).show();
+        Toast.makeText(FlutterBoost.instance().currentActivity().getApplicationContext(), "Add " +
+                "customized popRoute handler here", Toast.LENGTH_SHORT).show();
         return false;
     }
 }

--- a/example/lib/tab/simple_widget.dart
+++ b/example/lib/tab/simple_widget.dart
@@ -94,7 +94,14 @@ class _SimpleWidgetState extends State<SimpleWidget>
                       'open native page',
                       style: TextStyle(fontSize: 22.0, color: Colors.black),
                     )),
-                onTap: () => BoostNavigator.instance.push("native"),
+                onTap: () => BoostNavigator.instance.push("native").then(
+                        (value)  {
+                          if (mounted) {
+                            ScaffoldMessenger.of(context)
+                              ..removeCurrentSnackBar()
+                              ..showSnackBar(SnackBar(content: Text("$value")));
+                          }
+                        }),
               ),
               InkWell(
                 child: Container(


### PR DESCRIPTION
修复使用FlutterBoostFragment作为容器，唤起Native页面后，无法从Native页面获取结果的BUG。

示例中一直使用的是`FlutterBoost.instance().currentActivity()`作为`startActivityForResult`的对象，这个导致如果是使用`FlutterBoostFragment`承载Flutter页面，唤起Native页面后，无法从Native页面获取到回传数据。因此使用示例中，将`startActivityForResult`的对象，改为优先使用当前的`Container`。