### PR TITLE
change routeFactory to routeMap

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -427,14 +427,6 @@ class _MyAppState extends State<MyApp> {
     },
   };
 
-  Route<dynamic>? routeFactory(RouteSettings settings, String? uniqueId) {
-    FlutterBoostRouteFactory? func = routerMap[settings.name!];
-    if (func == null) {
-      return null;
-    }
-    return func(settings, uniqueId);
-  }
-
   @override
   void initState() {
     super.initState();
@@ -442,7 +434,7 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return FlutterBoostApp(routeFactory,
+    return FlutterBoostApp.routeMap(routerMap,
         // 如果自定了appBuilder，需要将传入的参数添加到widget层次结构中去，
         // 否则会导致FluttBoost初始化失败。
         appBuilder: (child) => MaterialApp(

--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -23,6 +23,23 @@ import 'messages.dart';
 typedef FlutterBoostAppBuilder = Widget Function(Widget home);
 
 class FlutterBoostApp extends StatefulWidget {
+
+  FlutterBoostApp.routeMap(
+        Map<String, FlutterBoostRouteFactory> routerMap, {
+        Key? key,
+        FlutterBoostAppBuilder? appBuilder,
+        String? initialRoute,
+
+        ///interceptors is to intercept push operation now
+        List<BoostInterceptor>? interceptors,
+      })  : appBuilder = appBuilder ?? _defaultAppBuilder,
+        interceptors = interceptors ?? <BoostInterceptor>[],
+        initialRoute = initialRoute ?? '/',
+        super(key: key) {
+    BoostNavigator.instance.routerMap = routerMap;
+  }
+
+  @Deprecated('Use [FlutterBoostApp.routeMap] instead.')
   FlutterBoostApp(
     FlutterBoostRouteFactory routeFactory, {
     Key? key,
@@ -743,7 +760,7 @@ class BoostPage<T> extends Page<T> {
   BoostPage._({LocalKey? key, required this.pageInfo})
       : super(
             key: key, name: pageInfo.pageName, arguments: pageInfo.arguments) {
-    _route = BoostNavigator.instance.routeFactory(this, pageInfo.uniqueId)
+    _route = BoostNavigator.instance.buildRoute(this, pageInfo.uniqueId)
         as Route<T>?;
     assert(_route != null,
         "Oops! Route name is not registered: '${pageInfo.pageName}'.");


### PR DESCRIPTION
主要解决`routeFactory`会多次调用的问题，将初始化的routeFactory方法改为routeMap，原有构造方法废弃，作为升级版本后的兼容方案予以保留。

fix #2122 ，fix #1869 ， fix #1599 