### PR TITLE
修复AGP在 8.0 以上,Android Api 设置34以上,强制要求 设置namespace 的问题.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "com.idlefish.flutterboost"
     compileSdkVersion 31
     buildToolsVersion '30.0.2'
     defaultConfig {


### PR DESCRIPTION

from  https://developer.android.com/build/configure-app-module#set-namespace