### PR TITLE
The operation to remove the 'Container' object is placed when 'deallo…

### DIFF
--- a/ios/Classes/FlutterBoostPlugin.h
+++ b/ios/Classes/FlutterBoostPlugin.h
@@ -41,6 +41,7 @@ typedef void (^FBVoidCallback)(void);
 - (void)containerDisappeared:(id<FBFlutterContainer>)container;
 - (void)containerDestroyed:(id<FBFlutterContainer>)container;
 - (void)onBackSwipe;
+- (void)removeContainerWhenDealloc:(id<FBFlutterContainer>)container;
 
 - (FBVoidCallback)addEventListener:(FBEventListener)listener forName:(NSString *)key;
 + (FlutterBoostPlugin* )getPlugin:(FlutterEngine*)engine ;

--- a/ios/Classes/FlutterBoostPlugin.m
+++ b/ios/Classes/FlutterBoostPlugin.m
@@ -85,10 +85,13 @@
   [self.flutterApi removeRouteParam:params
                          completion:^(NSError * e) {
                          }];
-  [self.containerManager removeContainerByUniqueId:vc.uniqueIDString];
-  if (self.containerManager.containerSize == 0) {
-    [FBLifecycle pause];
-  }
+}
+
+- (void)removeContainerWhenDealloc:(id<FBFlutterContainer>)container {
+    [self.containerManager removeContainerByUniqueId:container.uniqueIDString];
+    if (self.containerManager.containerSize == 0) {
+      [FBLifecycle pause];
+    }
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>  *)registrar {

--- a/ios/Classes/container/FBFlutterViewContainer.m
+++ b/ios/Classes/container/FBFlutterViewContainer.m
@@ -204,6 +204,7 @@ _Pragma("clang diagnostic pop")
   if (self.removeEventCallback != nil) {
     self.removeEventCallback();
   }
+  [FB_PLUGIN removeContainerWhenDealloc:self];
   [NSNotificationCenter.defaultCenter removeObserver:self];
   _leftEdgeGesture.delegate = nil;
 }


### PR DESCRIPTION
When using a Container, popping or dismissing it does not immediately trigger dealloc. Additionally, if a developer wants to hold a Container object for a longer period and try to use it repeatedly, an assertion error will be triggered because the cached 'uniqueId' is removed. This error can be avoided.