### PR TITLE
fix(FlutterBoostApp):直接匹配原生发过来的生命周期状态，避免转换为 Flutter 的生命周期状态导致不适配高版本Fl…

### DIFF
--- a/lib/src/flutter_boost_app.dart
+++ b/lib/src/flutter_boost_app.dart
@@ -133,11 +133,11 @@ class FlutterBoostAppState extends State<FlutterBoostApp> {
       //and 2 is paused
 
       final int? index = arguments["lifecycleState"];
-
-      if (index == AppLifecycleState.resumed.index) {
+      // 直接匹配原生发过来的生命周期状态，避免转换为 Flutter 的生命周期状态导致不适配高版本Flutter SDK
+      if (index == 0) {
         BoostFlutterBinding.instance!
             .changeAppLifecycleState(AppLifecycleState.resumed);
-      } else if (index == AppLifecycleState.paused.index) {
+      } else if (index == 2) {
         BoostFlutterBinding.instance!
             .changeAppLifecycleState(AppLifecycleState.paused);
       }


### PR DESCRIPTION
修复生命周期通知问题：
https://github.com/alibaba/flutter_boost/issues/2241