### PR TITLE
fix(android): 适配 Flutter 3.29+，用 FlutterLoader 替换已移除的 FlutterMain

### DIFF
--- a/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
+++ b/android/src/main/java/com/idlefish/flutterboost/FlutterBoost.java
@@ -19,7 +19,7 @@ import io.flutter.embedding.android.FlutterEngineProvider;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.dart.DartExecutor;
-import io.flutter.view.FlutterMain;
+import io.flutter.FlutterInjector;
 
 public class FlutterBoost {
     public static final String ENGINE_ID = "flutter_boost_default_engine";
@@ -86,7 +86,8 @@ public class FlutterBoost {
             // Pre-warm the cached FlutterEngine.
             engine.getNavigationChannel().setInitialRoute(options.initialRoute());
             engine.getDartExecutor().executeDartEntrypoint(new DartExecutor.DartEntrypoint(
-                    FlutterMain.findAppBundlePath(), options.dartEntrypoint()), options.dartEntrypointArgs());
+                    FlutterInjector.instance().flutterLoader().findAppBundlePath(),
+                    options.dartEntrypoint()), options.dartEntrypointArgs());
         }
         if (callback != null) callback.onStart(engine);
 


### PR DESCRIPTION
## 问题
`io.flutter.view.FlutterMain` 在 Flutter 3.29 已被移除（3.x 期间一直 deprecated），导致升级到 3.29+ 的用户 Android 编译失败：`cannot find symbol: FlutterMain`。对应 #2222、#2217。

## 改动
全仓库仅 `FlutterBoost.java` 一处用到该 API，替换为官方等价写法：

- `import io.flutter.view.FlutterMain` → `import io.flutter.FlutterInjector`
- `FlutterMain.findAppBundlePath()` → `FlutterInjector.instance().flutterLoader().findAppBundlePath()`

两者返回值均为 `String`；调用点在 `new FlutterEngine(...)` 之后，FlutterLoader 已初始化，调用安全。

## 兼容性
`FlutterInjector` 自 Flutter 1.20 起即存在，远早于本包要求的最低版本 3.0.0，低版本用户不受影响，无需版本分支或反射。

## 验证
对照真实 Flutter 3.32.0 引擎产物（`flutter_embedding`，engine hash `18818009…`）用 `javac` 核验：

- 旧写法 `import io.flutter.view.FlutterMain` → 编译失败（找不到符号），复现该 bug
- 新写法整条调用链 → 编译通过，`String` 正确传入 `DartExecutor.DartEntrypoint(String, String)`

> 注：本仓库 Android 侧无单测基建，该改动为编译期类型等价的官方 API 迁移，故未新增测试。

Closes #2222
Closes #2217